### PR TITLE
added udl schema check via appveyor and github action

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,21 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v1
+
+    - name: Install python modules
+      working-directory: 
+      run: python -m pip install requests jsonschema rfc3987 pywin32
+
+    - name: Validate json
+      working-directory: 
+      run: python validator.py
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: 1.0.{build}
+image: Visual Studio 2019
+
+
+environment:
+  matrix:
+  - PlatformToolset: v141_xp
+    PYTHON: "C:\\Python37"
+
+install:
+    - SET PATH=%PYTHON%;%PATH%
+    - python -m pip install requests jsonschema rfc3987 pywin32
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - call python validator.py

--- a/udl-list.json
+++ b/udl-list.json
@@ -24,16 +24,16 @@
 			"id-name": "STL-3dObject-ASCII.byPryrt",
 			"display-name": "STL 3dObject",
 			"version": "2020-Jan-12",
-			"respository": "",
+			"repository": "",
 			"description": "3d Stereolithography ASCII file (STL)",
 			"author": "Pryrt",
 			"homepage": "https://github.com/pryrt/"
 		},
-    		{
+			{
 			"id-name": "reStructuredText.bySteenhulthin",
 			"display-name": "reStructuredText",
 			"version": "2020-Jan-22",
-			"respository": "",
+			"repository": "",
 			"description": "Provides syntax higlighting for reStructuredText for Notepad++ through a user defined language file.",
 			"author": "steenhulthin",
 			"homepage": "https://github.com/steenhulthin/reStructuredText_NPP"

--- a/udl.schema
+++ b/udl.schema
@@ -1,0 +1,64 @@
+{
+	"type": "object",
+	"required": [
+		"name",
+		"version",
+		"UDLs"
+	],
+	"properties": {
+		"name": { "enum": ["npp-UDL-list"] },
+		"version": {
+			"type": "string",
+			"pattern": "^\\d+(\\.\\d+){,3}$"
+		},
+		"UDLs": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/udl" }
+		}
+	},
+	"definitions": {
+		"udl": {
+			"type": "object",
+			"required": [
+				"id-name",
+				"display-name",
+				"version",
+				"repository",
+				"description",
+				"author",
+				"homepage"
+			],
+			"properties": {
+				"id-name": {
+					"type": "string",
+					"minLength": 1
+				},
+				"display-name": {
+					"type": "string",
+					"minLength": 1
+				},
+				"version": {
+					"type": "string"
+				},
+				"repository": {
+					"oneOf": [
+						{"type": "string", "maxLength": 0},
+						{"format": "uri"}
+					]
+				},
+				"description": {
+					"type": "string"
+				},
+				"author": {
+					"type": "string"
+				},
+				"homepage": {
+					"oneOf": [
+						{"type": "string", "maxLength": 0},
+						{"format": "uri"}
+					]
+				}
+			}
+		}
+	}
+}

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,107 @@
+import json
+import os
+import io
+import sys
+
+import requests
+from hashlib import sha256
+from jsonschema import Draft4Validator, FormatChecker
+
+api_url = os.environ.get('APPVEYOR_API_URL')
+has_error = False
+
+
+def post_error(message):
+    global has_error
+
+    has_error = True
+
+    message = {
+        "message": message,
+        "category": "error",
+        "details": ""
+    }
+
+    if api_url:
+        requests.post(api_url + "api/build/messages", json=message)
+    else:
+        from pprint import pprint
+        pprint(message)
+
+def parse(filename):
+    try:
+        schema = json.loads(open("udl.schema").read())
+        schema = Draft4Validator(schema, format_checker=FormatChecker())
+    except ValueError as e:
+        post_error("udl.schema - " + str(e))
+        return
+
+    try:
+        udlfile = json.loads(open(filename).read())
+    except ValueError as e:
+        post_error(filename + " - " + str(e))
+        return
+
+    for error in schema.iter_errors(udlfile):
+        post_error(error.message)
+
+    idnames = []
+    displaynames = []
+    repositories = []
+
+    for udl in udlfile["UDLs"]:
+        print(udl["display-name"])
+
+        try:
+            if udl["repository"] != "" :
+                response = requests.get(udl["repository"])
+        except requests.exceptions.RequestException as e:
+            post_error(str(e))
+            continue
+
+        if response.status_code != 200:
+            post_error(f'{udl["display-name"]}: failed to download udl. Returned code {response.status_code}')
+            continue
+
+        # Hash it and make sure its what is expected
+        #hash = sha256(response.content).hexdigest()
+        #if udl["id"].lower() != hash.lower():
+        #    post_error(f'{udl["display-name"]}: Invalid hash. Got {hash.lower()} but expected {udl["id"]}')
+        #    continue
+
+        #check uniqueness of json id-name, display-name and repository
+        found = False
+        for name in displaynames :
+           if udl["display-name"] == name :
+               post_error(f'{udl["display-name"]}: non unique display-name entry')
+               found = True
+        if found == False:
+               displaynames.append(udl["display-name"])
+
+        found = False
+        for idname in idnames :
+           if udl["id-name"] == idname :
+               post_error(f'{udl["id-name"]}: non unique id-name entry')
+               found = True
+        if found == False:
+           idnames.append(udl["id-name"])
+
+        found = False
+        for repo in repositories :
+           if udl["repository"] != "" and udl["repository"] == repo :
+                   post_error(f'{udl["repository"]}: non unique repository entry')
+                   found = True
+        if found == False:
+           repositories.append(udl["repository"])
+
+
+
+
+
+
+parse("udl-list.json")
+
+if has_error:
+    sys.exit(-2)
+else:
+    sys.exit()


### PR DESCRIPTION
@donho Do you prefer github actions https://github.com/chcg/userDefinedLanguages/commit/cff1c0d7a5c963cfefccc248819f77c6ab9ce914/checks?check_suite_id=397742873
 and/or appveyor https://ci.appveyor.com/project/chcg/userdefinedlanguages/builds/30075891
to check the udl. The schema check for the an empty repo or version is not working yet.
How do you think the check of a locally available udl vs. the one from the list should happen to see which one is newer? For plugins the dll version was used, but that is currently not possible for UDLs.