### PR TITLE
reStructuredText

### DIFF
--- a/UDLs/reStructuredText.bySteenhulthin.xml
+++ b/UDLs/reStructuredText.bySteenhulthin.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="reStructuredText" ext="rst" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="yes" Keywords2="yes" Keywords3="no" Keywords4="no" Keywords5="yes" Keywords6="yes" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00 01 02 03 04</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1">.</Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1"></Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1"> &gt; :a :b :c :d :e :f :g :h :i :j :k :l :m :n :o :p :q :r :s :t :u :v :w :x :y :z</Keywords>
+            <Keywords name="Keywords2">http &lt;http ftp:// ftps:// &lt;ftp</Keywords>
+            <Keywords name="Keywords3">admonition:: attention:: caution:: class:: code:: compound:: container:: contents:: csv-table:: danger:: date:: default-role:: epigraph:: error:: figure:: footer:: header:: highlights:: hint:: image:: important:: include:: line-block:: list-table:: math:: meta:: note:: parsed-literal:: pull-quote:: raw:: replace:: role:: rubric:: section-autonumbering:: sectnum:: sidebar:: table:: target-notes:: tip:: title:: toctree:: topic:: unicode:: warning::</Keywords>
+            <Keywords name="Keywords4">#. - +</Keywords>
+            <Keywords name="Keywords5">== -- ^^ ~~ +== +--</Keywords>
+            <Keywords name="Keywords6">_</Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00[ 00`` 00` 00| 01 02] 02`` 02` 02((| EOL)) 03_` 04 05` 06** 06* 07 08((** EOL)) 08((* EOL)) 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="797979" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="8080FF" bgColor="FFFFFF" fontName="" fontStyle="3" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="10" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="3399FF" bgColor="FFFFFF" fontName="" fontStyle="4" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="8080FF" bgColor="FFFFFF" fontName="" fontStyle="3" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="FFA600" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="3399FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="FFA600" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="8080FF" bgColor="FFFFFF" fontName="" fontStyle="2" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="FFA600" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -50,8 +50,8 @@
     		{
 			"id-name": "reStructuredText.bySteenhulthin",
 			"display-name": "reStructuredText",
-			"version": "2020-Jan-20",
-			"respository": "https://github.com/steenhulthin/reStructuredText_NPP/blob/master/reStructuredText.xml",
+			"version": "2020-Jan-22",
+			"respository": "",
 			"description": "Provides syntax higlighting for reStructuredText for Notepad++ through a user defined language file.",
 			"author": "steenhulthin",
 			"homepage": "https://github.com/steenhulthin/reStructuredText_NPP"

--- a/udl-list.json
+++ b/udl-list.json
@@ -46,6 +46,15 @@
 			"description": "3d Stereolithography ASCII file (STL)",
 			"author": "Pryrt",
 			"homepage": "https://github.com/pryrt/"
+		},
+    		{
+			"id-name": "reStructuredText.bySteenhulthin",
+			"display-name": "reStructuredText",
+			"version": "2020-Jan-20",
+			"respository": "https://github.com/steenhulthin/reStructuredText_NPP/blob/master/reStructuredText.xml",
+			"description": "Provides syntax higlighting for reStructuredText for Notepad++ through a user defined language file.",
+			"author": "steenhulthin",
+			"homepage": "https://github.com/steenhulthin/reStructuredText_NPP"
 		}
-    ]
+]
 }


### PR DESCRIPTION
So, I have a first attempt at packaging up @cup's request from #5 

However, here is where some of our naming-rules come in: the underlying file in the https://github.com/steenhulthin/reStructuredText_NPP repo is named `reStructuredText.xml`, without any additional identifiers, so is in violation of our rules.  @cup is a third-part requesting that we include @steenhulthin's UDL

The `id-name` can obviously be something unique like `reStructuredText.bySteenhulthin`, like I used in my PR , but that then gets a mismatch between the id-name and the actual filename in the remote repo (as linked in `repository` attribute).

Do we 1) just reject @cup's request; 2) ask @steenhulthin to rename the file in his repo (or make a copy with our naming rules); 3) ask @steenhulthin if we can make a duplicate of his `.xml` in our repo, but with our naming convention; or 4) allow the mismatch between `id-name` and the filename in `repository`?