### PR TITLE
Add TeraTermLanguage UDL file

### DIFF
--- a/UDLs/TeraTermLanguage_allCmdsV4.xml
+++ b/UDLs/TeraTermLanguage_allCmdsV4.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="TTL" ext="ttl" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00; 01 02 03 04</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1"></Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">break call continue do loop end execcmnd exit for next goto if then elseif else endif include mpause pause return until enduntil while endwhile</Keywords>
+            <Keywords name="Keywords2">bplusrecv bplussend callmenu changedir clearscreen closett connect cygconnect disconnect dispstr enablekeyb flushrecv gethostname getmodemstatus gettitle kmtfinish kmtget kmtrecv kmtsend loadkeymap logautoclosemode logclose loginfo logopen logpause logrotate logstart logwrite quickvanrecv quickvansend recvln restoresetup scprecv scpsend send sendbreak sendbroadcast sendfile sendkcode sendln sendlnbroadcast sendlnmulticast sendmulticast setbaud setdebug setdtr setecho setflowctrl setmulticastname setrts setspeed setsync settitle showtt testlink unlink wait wait4all waitevent waitln waitn waitrecv waitregex xmodemrecv xmodemsend ymodemrecv ymodemsend zmodemrecv zmodemsend</Keywords>
+            <Keywords name="Keywords3">basename dirname fileclose fileconcat filecopy filecreate filedelete filelock filemarkptr fileopen filereadln fileread filerename filesearch fileseek fileseekback filestat filestrseek filestrseek2 filetruncate fileunlock filewrite filewriteln findfirst, findnext, findclose foldercreate folderdelete foldersearch getdir getfileattr makepath setdir setfileattr</Keywords>
+            <Keywords name="Keywords4">beep bringupbox checksum8 checksum8file checksum16 checksum16file checksum32 checksum32file closesbox clipb2var crc16 crc16file crc32 crc32file exec dirnamebox filenamebox getdate getenv getipv4addr getipv6addr getspecialfolder gettime getttdir getver ifdefined inputbox intdim listbox messagebox random rotateleft rotateright setdate setdlgpos setenv setexitcode settime show statusbox strdim uptime var2clipb yesnobox</Keywords>
+            <Keywords name="Keywords5">code2str expandenv int2str regexoption sprintf sprintf2 str2code str2int strcompare strconcat strcopy strinsert strjoin strlen strmatch strremove strreplace strscan strspecial strsplit strtrim tolower toupper</Keywords>
+            <Keywords name="Keywords6">delpassword getpassword ispassword passwordbox setpassword</Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00&apos; 01 02&apos; 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="008040" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="FF4000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -1697,6 +1697,14 @@
 			"author": "Patrick Druley <mailto:patrick.s.druley@gmail.com>"
 		},
 		{
+			"id-name": "TeraTermLanguage_allCmdsV4",
+			"display-name": "TTL",
+			"version": "2020-May-06",
+			"repository": "",
+			"description": "TeraTermLanguage support with highlighting of all cmds of V4",
+			"author": "Simon Buhrow <mailto:simon.buhrow@posteo.de>"
+		},
+        {
 			"id-name": "TeradataTools-v13_byTrevorOGrady",
 			"display-name": "Teradata Tools v13",
 			"version": "Sun, 18 Mar 2012 17:52:57 GMT",

--- a/udl-list.md
+++ b/udl-list.md
@@ -224,6 +224,7 @@
 | [Template Toolkit](./UDLs/TemplateToolkit-TT_byAndreyEfremov.xml) | Template Toolkit | Andrey Efremov |
 | [Teradata Macro Language (Term)](./UDLs/TeradataMacroLanguage-Term_byPatrickDruley.xml) | Teradata Macro Language (Term) | Patrick Druley |
 | [Teradata Tools v13](./UDLs/TeradataTools-v13_byTrevorOGrady.xml) | Teradata Tools v13 | Trevor O'Grady |
+| [Tera Term Language](./UDLs/TeraTermLanguage_allCmdsV4.xml) | Tera Term Language | Simon Buhrow
 | [TexCnc](./UDLs/TexCnc_by-fixus971.xml) | TexCnc | fixus971 |
 | [Thrift](./UDLs/thrift_by-mail507.xml) | Thrift | mail507 |
 | [Tiny Fugue](./UDLs/TinyFugue_byYrwin.xml) | Tiny Fugue | Yrwin |


### PR DESCRIPTION
TeraTermLanguage (TTL) is a macro language for the free software terminal emulator (communication program)  Tera Term.

There is already a UDL file pointing to this but it has no cmd highlighting at all.

For cmd reference see:
https://ttssh2.osdn.jp/manual/4/en/macro/command/index.html

For code example:
```
; Script to test highlighting

i = 4
do while i>0
	i = i - 1
	sendln 'Something'
	mpause 2000 ; wait for x ms
	flushrecv
loop

dispstr 'MACRO: END'
```