### PR TITLE
Update Markdown Modern to Markdown-plus-plus v3.2.0

### DIFF
--- a/udl-list.json
+++ b/udl-list.json
@@ -3,13 +3,13 @@
 	"version": "1.0",
 	"UDLs": [
 		{
-			"id-name": "userDefinedLang-markdown.default.modern",
-			"display-name": "Markdown Modern",
-			"version": "",
-			"repository": "https://raw.githubusercontent.com/Edditoria/markdown-plus-plus/master/udl/markdown.default.udl.xml",
-			"description": "Markdown modern",
+			"id-name": "markdown-plus-plus",
+			"display-name": "Markdown-plus-plus",
+			"version": "3.2.0",
+			"repository": "https://github.com/Edditoria/markdown-plus-plus",
+			"description": "Markdown syntax highlighting. In dev stage of supporting GitHub Flavored Markdown (GFM). More themes to download in the repository.",
 			"author": "Edditoria",
-			"homepage": "https://github.com/Edditoria/markdown-plus-plus/"
+			"homepage": "https://github.com/Edditoria"
 		},
 		{
 			"id-name": "AutoCAD-LPSS.udl",

--- a/udl-list.md
+++ b/udl-list.md
@@ -128,7 +128,7 @@
 | [MSC-Patran](./UDLs/MSC-Patran_by-onurarifyasa.xml) | MSC-Patran | Onur Arif Yaşa |
 | [MSL](./UDLs/MSL_byAnonymous_in2009.xml) | MSL |  |
 | [ManiaScript](./UDLs/Maniascript_byMagnetiK.xml) | ManiaScript | [MagnetiK](https://github.com/maniaplanet/notepadplusplus-Maniascript) |
-| [Markdown Modern](https://github.com/Edditoria/markdown-plus-plus/blob/master/theme-default/userDefinedLang-markdown.default.modern.xml) | Markdown modern | [Edditoria](https://github.com/Edditoria/markdown-plus-plus/) | Markdown modern | [Edditoria](https://github.com/Edditoria/markdown-plus-plus/) |
+| [Markdown (preinstalled)](https://github.com/Edditoria/markdown-plus-plus/blob/master/udl/markdown._preinstalled.udl.xml) | Markdown, GFM supported. More themes in project site :arrow_right: | [Edditoria](https://github.com/Edditoria/markdown-plus-plus) |
 | [Mathematica](./UDLs/Mathematica-mma_byAkater.xml) | Mathematica | Akater |
 | [MediaWiki markup (Obsidian theme)](./UDLs/MediaWiki_userDefineLang__Obsidian_Theme_.xml) | MediaWiki markup (Obsidian theme) | CJ O'Reilly |
 | [MediaWiki markup](./UDLs/MediawikiMarkup_Improved_bySaurabhPatil.xml) | MediaWiki markup | Saurabh Patil |


### PR DESCRIPTION
Thank you for the list. I would like to update the information of my Markdown repo.

- Update from v2 (version Markdown Modern) to v3.
- Some improvement in syntax.
- Re-written build scripts from ground (e.g. 1-line npm command to build and download).
- Filename starts with "m". Better view of file-list in Explorer.

Thanks. :smile_cat: