### PR TITLE
6502 Assembly UDL addition

### DIFF
--- a/UDLs/6502Assembly_byCarlMyerholtz.xml
+++ b/UDLs/6502Assembly_byCarlMyerholtz.xml
@@ -1,0 +1,67 @@
+<NotepadPlus>
+    <UserLang name="6502 Assembly" ext="s cba" udlVersion="2.1">
+        <Author>
+            <field name="Carl Myerholtz W9OMS"
+        </Author>
+        <Settings>
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="yes" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00; 01 02 03; 04</Keywords>
+            <Keywords name="Numbers, prefix1">%</Keywords>
+            <Keywords name="Numbers, prefix2">$ #$ #</Keywords>
+            <Keywords name="Numbers, extras1">0 A B C D E F a b c d e f 0</Keywords>
+            <Keywords name="Numbers, extras2">0 A B C D E F a b c d e f</Keywords>
+            <Keywords name="Numbers, suffix1">,</Keywords>
+            <Keywords name="Numbers, suffix2">,</Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1"></Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">ADC AND ASL BCC BCS BEQ BNE BMI BPL BVC BVS BIT BRK CLC CLD CLI CLV CMP CPX CPY DEC DEX DEY EOR INC INX INY JMP JSR LDA LDX LDY LSR NOP ORA PHA PHP PLP PLA ROL ROR RTI RTS SBC SEC SED SEI STA STX STY TAX TAY TSX TXA TXS TYA</Keywords>
+            <Keywords name="Keywords2">.align .byte .db .ds .dw .echo .end .equ .eseg .files .fill .include .list .nolist .org .page .print .skipb .skipw .str .stra .strx .strz .text .title .word</Keywords>
+            <Keywords name="Keywords3"></Keywords>
+            <Keywords name="Keywords4"></Keywords>
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00( 01 02) 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="-1" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="0000FF" bgColor="FFFFFF" fontName="&#xC227;&#x8FCA;&#x0200;&#x8000;" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="FF0000" bgColor="FFFFFF" fontName="&#x1608;&#x072E;&#x09F0;&#x072E;&#x1068;&#x072E;&#x1758;&#x072E;&#x16F8;&#x072E;&#x18C0;&#x072E;&#x1170;&#x072E;" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="8080FF" bgColor="FFFFCC" fontName="&#x0202;&#x0202;&#x0202;&#x0201;&#x0101;&#x0100;&#x0100;&#x0200;&#x0102;&#x0202;&#x0201;&#x0102;&#x0201;&#x0101;&#x0100;&#x0100;&#x0200;&#x0102;&#x0202;&#x0102;&#x0102;&#x0201;&#x0202;&#x0100;&#x0100;&#x0200;&#x0102;&#x0202;&#x0202;&#x0202;&#x0201;&#x0101;&#x0100;&#x0100;&#x0200;&#x0102;&#x0202;&#x0101;&#x0102;&#x0201;&#x0101;&#x0100;&#x0100;&#x0200;&#x0102;&#x0202;&#x0201;&#x0102;&#x0201;&#x0202;&#x0202;&#x0202;&#x0202;&#x0202;&#x0202;&#x0202;&#x0202;&#x0202;" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="000000" bgColor="FFFFFF" fontName="&#x0001;" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontName="-1" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="FF00FF" bgColor="FFFFFF" fontName="&#x1254;&#x7004;&#x0001;" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/UDLs/6502Assembly_byCarlMyerholtz.xml
+++ b/UDLs/6502Assembly_byCarlMyerholtz.xml
@@ -1,7 +1,7 @@
 <NotepadPlus>
     <UserLang name="6502 Assembly" ext="s cba" udlVersion="2.1">
         <Author>
-            <field name="Carl Myerholtz W9OMS"
+            <field name="Carl Myerholtz W9OMS"/>
         </Author>
         <Settings>
             <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />

--- a/udl-list.json
+++ b/udl-list.json
@@ -5,7 +5,7 @@
 		{
 			"id-name": "6502Assembly_byCarl_Myerholtz",
 			"display-name": "6502 Assembly",
-			"version": "Tue, 31 May 2011 07:12:47 GMT",
+			"version": "Sun, 8 Nov 2020 22:01:00 GMT",
 			"repository": "",
 			"description": "ASM for 6502",
 			"author": "Carl Myerholtz W9OMS <mailto:carl_myerholtz@yahoo.com>"

--- a/udl-list.json
+++ b/udl-list.json
@@ -3,6 +3,14 @@
 	"version": "1.0",
 	"UDLs": [
 		{
+			"id-name": "6502Assembly_byCarl_Myerholtz",
+			"display-name": "6502 Assembly",
+			"version": "Tue, 31 May 2011 07:12:47 GMT",
+			"repository": "",
+			"description": "ASM for 6502",
+			"author": "Carl Myerholtz W9OMS <mailto:carl_myerholtz@yahoo.com>"
+		},
+		{
 			"id-name": "markdown-plus-plus",
 			"display-name": "Markdown-plus-plus",
 			"version": "3.2.0",

--- a/udl-list.md
+++ b/udl-list.md
@@ -1,6 +1,7 @@
 
 | Name | Description | Author |
 |------|-------------|-------:|
+| [6502 Assembly](./UDLs/| [ASM for Intel 8051](./UDLs/6502Assembly_byCarlMyerholtz.xml) | ASM for 6502 | Carl Myerholtz |
 | [3GL](./UDLs/3GL_byDrezzzz.xml) | 3GL | drezzzzz |
 | [68k Assembly](./UDLs/68K_Assembly_byAmix73.xml) | 68k Assembly | Amix 73 |
 | [ABAP](./UDLs/ABAP_by_ChristianKosasih.xml) | ABAP | Christian Kosasih |

--- a/udl-list.md
+++ b/udl-list.md
@@ -1,7 +1,7 @@
 
 | Name | Description | Author |
 |------|-------------|-------:|
-| [6502 Assembly](./UDLs/| [ASM for Intel 8051](./UDLs/6502Assembly_byCarlMyerholtz.xml) | ASM for 6502 | Carl Myerholtz |
+| [6502 Assembly](./UDLs/6502Assembly_byCarlMyerholtz.xml) | ASM for 6502 | Carl Myerholtz |
 | [3GL](./UDLs/3GL_byDrezzzz.xml) | 3GL | drezzzzz |
 | [68k Assembly](./UDLs/68K_Assembly_byAmix73.xml) | 68k Assembly | Amix 73 |
 | [ABAP](./UDLs/ABAP_by_ChristianKosasih.xml) | ABAP | Christian Kosasih |


### PR DESCRIPTION
I have added a UDL to support 6502 op codes that facilitates view and editing 6502 assembly source code. The 6502 was a very popular early microprocessor with much ongoing interest and support especially among those interested in vintage computing. Much more information can be found at http://6502.org/