### PR TITLE
- take over correction of validator_xml.py check from N++

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-   - PYTHON: "C:\\Python38"
+   - PYTHON: "C:\\Python39"
 
 install:
-    - SET PATH=%PYTHON%;%PATH%
+    - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
     - python -m pip install requests jsonschema rfc3987 pywin32 lxml
 
 build_script:

--- a/autoCompletions/RenderMan-RSL_by-focus_gfx.xml
+++ b/autoCompletions/RenderMan-RSL_by-focus_gfx.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
 @author	 Mohamed Samir - focus_gfx@hotmail.com
 @version	1.00

--- a/validator_xml.py
+++ b/validator_xml.py
@@ -36,13 +36,9 @@ def parse_xml_file(filename_xml):
     #with open(filename_xsd, 'r') as schema_file:
         #schema_to_check = schema_file.read()
 
-    # open and read xml file
-    with open(filename_xml, 'r', encoding="utf-8") as xml_file:
-        xml_to_check = xml_file.read()
-
     # parse xml
     try:
-        doc = etree.parse(io.StringIO(xml_to_check))
+        doc = etree.parse(filename_xml)
         #print(f'{filename_xml} XML well formed, syntax ok.')
 
     # check for file IO error


### PR DESCRIPTION
- take over correction of validator_xml.py check from N++ (https://github.com/notepad-plus-plus/notepad-plus-plus/pull/9339) to use the encoding from the xml header
- update python 3.8 -> 3.9 for appveyor
- update further requirements to current versions