### PR TITLE
Make Vim script themes adaptable to dark mode

### DIFF
--- a/UDL-samples/Vimscript_by_rdipardo.vimrc
+++ b/UDL-samples/Vimscript_by_rdipardo.vimrc
@@ -1,5 +1,5 @@
-" Source: https://github.com/fatih/vim-go-tutorial/blob/master/vimrc
 " Edited, with additions to demonstrate more highlighting features
+" from https://github.com/fatih/vim-go-tutorial/blob/master/vimrc
 "
 " Copyright (c) 2016, Fatih Arslan All rights reserved.
 "
@@ -86,3 +86,5 @@ func! s:build_go_files() abort
     call go#cmd#Build(0)
   endif
 endfunc
+
+" vim: syntax=vim

--- a/UDLs/Vimscript_Obsidian_by_rdipardo.xml
+++ b/UDLs/Vimscript_Obsidian_by_rdipardo.xml
@@ -37,24 +37,24 @@
       <Keywords name="Keywords8">assert_ balloon_ ch_ get job_ popup_ prompt_ prop_ remote_ sign_ term_ test_ timer_ win_</Keywords>
     </KeywordLists>
     <Styles>
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="FFF0F5" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="COMMENT" styleID="1" fgColor="8F9CA2" bgColor="293134" fontName="" fontStyle="2"/>
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="8F9CA2" bgColor="293134" fontName="" fontStyle="2"/>
-      <WordsStyle name="FOLDEROPEN" styleID="3" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="FOLDERCLOSE" styleID="4" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="FOLDER IN COMMENT" styleID="5" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="NUMBERS" styleID="6" fgColor="FFEF00" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="OPERATORS" styleID="7" fgColor="678CB1" bgColor="293134" fontName="" fontStyle="1"/>
-      <WordsStyle name="KEYWORDS1" styleID="8" fgColor="A082BD" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="KEYWORDS2" styleID="9" fgColor="93CDBA" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="KEYWORDS3" styleID="10" fgColor="37A690" bgColor="293134" fontName="" fontStyle="1"/>
-      <WordsStyle name="KEYWORDS4" styleID="11" fgColor="93CDBA" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="KEYWORDS5" styleID="12" fgColor="B3B689" bgColor="293134" fontName="" fontStyle="1"/>
-      <WordsStyle name="KEYWORDS6" styleID="13" fgColor="BC8F8F" bgColor="293134" fontName="" fontStyle="3"/>
-      <WordsStyle name="KEYWORDS7" styleID="14" fgColor="BC8F8F" bgColor="293134" fontName="" fontStyle="3"/>
-      <WordsStyle name="KEYWORDS8" styleID="15" fgColor="37A690" bgColor="293134" fontName="" fontStyle="1"/>
-      <WordsStyle name="DELIMITERS1" styleID="16" fgColor="FF7F50" bgColor="293134" fontName="" fontStyle="0"/>
-      <WordsStyle name="DELIMITERS2" styleID="17" fgColor="FF7F50" bgColor="293134" fontName="" fontStyle="0"/>
+      <WordsStyle name="DEFAULT" styleID="0" fgColor="FFF0F5" bgColor="293134" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="COMMENT" styleID="1" fgColor="8F9CA2" bgColor="293134" colorStyle="1" fontName="" fontStyle="2"/>
+      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="8F9CA2" bgColor="293134" colorStyle="1" fontName="" fontStyle="2"/>
+      <WordsStyle name="FOLDEROPEN" styleID="3" fgColor="E0E2E4" bgColor="293134" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="FOLDERCLOSE" styleID="4" fgColor="E0E2E4" bgColor="293134" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="FOLDER IN COMMENT" styleID="5" fgColor="E0E2E4" bgColor="293134" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="NUMBERS" styleID="6" fgColor="FFEF00" bgColor="293134" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="OPERATORS" styleID="7" fgColor="678CB1" bgColor="293134" colorStyle="1" fontName="" fontStyle="1"/>
+      <WordsStyle name="KEYWORDS1" styleID="8" fgColor="A082BD" bgColor="293134" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="KEYWORDS2" styleID="9" fgColor="93CDBA" bgColor="293134" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="KEYWORDS3" styleID="10" fgColor="37A690" bgColor="293134" colorStyle="1" fontName="" fontStyle="1"/>
+      <WordsStyle name="KEYWORDS4" styleID="11" fgColor="93CDBA" bgColor="293134" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="KEYWORDS5" styleID="12" fgColor="B3B689" bgColor="293134" colorStyle="1" fontName="" fontStyle="1"/>
+      <WordsStyle name="KEYWORDS6" styleID="13" fgColor="BC8F8F" bgColor="293134" colorStyle="1" fontName="" fontStyle="3"/>
+      <WordsStyle name="KEYWORDS7" styleID="14" fgColor="BC8F8F" bgColor="293134" colorStyle="1" fontName="" fontStyle="3"/>
+      <WordsStyle name="KEYWORDS8" styleID="15" fgColor="37A690" bgColor="293134" colorStyle="1" fontName="" fontStyle="1"/>
+      <WordsStyle name="DELIMITERS1" styleID="16" fgColor="FF7F50" bgColor="293134" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="DELIMITERS2" styleID="17" fgColor="FF7F50" bgColor="293134" colorStyle="1" fontName="" fontStyle="0"/>
     </Styles>
   </UserLang>
 </NotepadPlus>

--- a/UDLs/Vimscript_by_rdipardo.xml
+++ b/UDLs/Vimscript_by_rdipardo.xml
@@ -36,24 +36,24 @@
       <Keywords name="Keywords8">assert_ balloon_ ch_ get job_ popup_ prompt_ prop_ remote_ sign_ term_ test_ timer_ win_</Keywords>
     </KeywordLists>
     <Styles>
-      <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="COMMENT" styleID="1" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="2"/>
-      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="2"/>
-      <WordsStyle name="FOLDEROPEN" styleID="3" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="FOLDERCLOSE" styleID="4" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="FOLDER IN COMMENT" styleID="5" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="NUMBERS" styleID="6" fgColor="FF0000" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="OPERATORS" styleID="7" fgColor="378BBA" bgColor="FFFFFF" fontName="" fontStyle="1"/>
-      <WordsStyle name="KEYWORDS1" styleID="8" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="KEYWORDS2" styleID="9" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="KEYWORDS3" styleID="10" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="1"/>
-      <WordsStyle name="KEYWORDS4" styleID="11" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="KEYWORDS5" styleID="12" fgColor="5C2C26" bgColor="FEFDE0" fontName="" fontStyle="2"/>
-      <WordsStyle name="KEYWORDS6" styleID="13" fgColor="5C2C26" bgColor="FFFFFF" fontName="" fontStyle="3"/>
-      <WordsStyle name="KEYWORDS7" styleID="14" fgColor="5C2C26" bgColor="FFFFFF" fontName="" fontStyle="3"/>
-      <WordsStyle name="KEYWORDS8" styleID="15" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="DELIMITERS1" styleID="16" fgColor="B72F14" bgColor="FFFFFF" fontName="" fontStyle="0"/>
-      <WordsStyle name="DELIMITERS2" styleID="17" fgColor="5C2C26" bgColor="FFFFFF" fontName="" fontStyle="0"/>
+      <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="COMMENT" styleID="1" fgColor="008000" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="2"/>
+      <WordsStyle name="COMMENT LINE" styleID="2" fgColor="008000" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="2"/>
+      <WordsStyle name="FOLDEROPEN" styleID="3" fgColor="0000FF" bgColor="FFFFFF" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="FOLDERCLOSE" styleID="4" fgColor="0000FF" bgColor="FFFFFF" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="FOLDER IN COMMENT" styleID="5" fgColor="008000" bgColor="FFFFFF" colorStyle="0" fontName="" fontStyle="0"/>
+      <WordsStyle name="NUMBERS" styleID="6" fgColor="FF0000" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="OPERATORS" styleID="7" fgColor="378BBA" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="1"/>
+      <WordsStyle name="KEYWORDS1" styleID="8" fgColor="0000FF" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="KEYWORDS2" styleID="9" fgColor="8000FF" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="KEYWORDS3" styleID="10" fgColor="8000FF" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="1"/>
+      <WordsStyle name="KEYWORDS4" styleID="11" fgColor="8000FF" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="KEYWORDS5" styleID="12" fgColor="5C2C26" bgColor="FEFDE0" colorStyle="1" fontName="" fontStyle="2"/>
+      <WordsStyle name="KEYWORDS6" styleID="13" fgColor="5C2C26" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="3"/>
+      <WordsStyle name="KEYWORDS7" styleID="14" fgColor="5C2C26" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="3"/>
+      <WordsStyle name="KEYWORDS8" styleID="15" fgColor="8000FF" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="DELIMITERS1" styleID="16" fgColor="B72F14" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
+      <WordsStyle name="DELIMITERS2" styleID="17" fgColor="5C2C26" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0"/>
     </Styles>
   </UserLang>
 </NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -2296,7 +2296,7 @@
 		{
 			"id-name": "Vimscript_by_rdipardo",
 			"display-name": "Vim script",
-			"version": "2021-02-18",
+			"version": "2021-11-21",
 			"repository": "https://gist.github.com/0b78f62e1ce481ff0d8f8e80cc298ced.git",
 			"description": "User Defined Language for Vim script",
 			"author": "Robert Di Pardo",
@@ -2305,7 +2305,7 @@
 		{
 			"id-name": "Vimscript_Obsidian_by_rdipardo",
 			"display-name": "Vim script (Obsidian)",
-			"version": "2021-02-18",
+			"version": "2021-11-21",
 			"repository": "https://gist.github.com/b8d586e156f543afc84690ac9ddf8e91.git",
 			"description": "User Defined Language for Vim script (based on the Obsidian theme)",
 			"author": "Robert Di Pardo",


### PR DESCRIPTION
Similar to 38fc23b, this allows both Vim script themes to blend in with dark backgrounds.

I see N++'s UDL menu now has the option to customize background style (*), but the hard-coded approach works in all versions (**), and convenient default values for the `colorStyle` attribute is a nicer user experience, IMHO.

An extra tiny fix was thrown in after noticing that GitHub was serving the Vim script sample as plain text.

---
(*) notepad-plus-plus/notepad-plus-plus@32d5307

(**) Showing 8.1.2 (64-bit)

![vimscript obsidian dm hl](https://user-images.githubusercontent.com/59004801/142921979-14ab8bd9-5978-482a-b411-793e94be9c56.png)
