### PR TITLE
clarify UDL XML download options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,26 @@ For now, you have to manually install a new User Defined Language.
 
 1. Download the XML file from the [`UDL list`](./udl-list.md) of this Collection.
    - From the [`UDL list`](./udl-list.md), click on the name of the file.
-   - From the file's page, click on either the "Raw" button (which will take you to a page where you can copy/paste the raw contents), or even easier, just click on the copy raw contents button, which will immediately place the raw contents in your clipboard for pasting.
-       ![image](https://user-images.githubusercontent.com/17455758/185504202-754541f7-ee6f-4e77-9a6b-2338448e0dfa.png)
-   - Do not just right click to try to download the file from either the [`UDL list`](./udl-list.md) or the [directory listing on GitHub](https://github.com/notepad-plus-plus/userDefinedLanguages/tree/master/UDLs), as either of those right-click actions will download the GitHub web page for that file (which is not the UDL's XML file and will not work).
-2. Import the file by placing the file in your `userDefineLangs` folder and restarting Notepad++.  (It is also possible to use the User Defined Language dialog box and click **Import**, but that method is the "old way" and is no longer recommended: it's more steps, and harder to maintain, so there is no good reason to do it that way).  More details of what those steps entail can be found in the ["Import a UDL" section](https://npp-user-manual.org/docs/user-defined-language-system/#import-a-udl) of the official documentation.
-3. If the UDL author provided an sample file that uses that UDL, you may download that from the `UDL-samples` folder of the repository.
-4. If the UDL author provided an autoCompletion XML file for that UDL, you may download it from the `autoCompletions` folder of the repository, and put it in the `autoCompletion\` sub-folder of your Notepad++ installation directory.  More details can be found in the online User Manual in the ["autoCompletion"](https://npp-user-manual.org/docs/auto-completion/) and ["configuration files details"](https://npp-user-manual.org/docs/config-files/#other-configuration-files) sections.
+   - From the file's page, there are two buttons (the "Raw" button on the left, or the double-square icon farther right): either of these buttons can be used to get the actual XML contents, but they behave slightly differently
+       <br>![image](https://user-images.githubusercontent.com/17455758/185504202-754541f7-ee6f-4e77-9a6b-2338448e0dfa.png)
+       - Choice 1: If you click on the button on the left, it will open up a plain-text page in the web browser, which shows the raw XML text for the UDL.
+           <br>![image](https://user-images.githubusercontent.com/17455758/193082422-d9c68744-c840-44c4-9e08-85f93985c960.png)
+           - From the resulting screen, you can either 
+               - copy the text, and paste it into a new file in Notepad++, and save it as an XML file to a known location (or directly to the `userDefineLangs` folder in step 2)
+               - or you can use your browser's **Right Click > Save As...** feature to save it in a known location (or directly to the `userDefineLangs` folder in step 2)
+       - Choice 2: If you click on the button on the right, the raw contents will be in the clipboard
+           <br>Pressing this icon ![image](https://user-images.githubusercontent.com/17455758/193082624-c67b4c77-35bd-4386-9d83-b882e0208565.png) will make it process briefly, then become this new icon ![image](https://user-images.githubusercontent.com/17455758/193084173-b36a8d5d-f057-4d89-98a8-c98e8a7f331d.png)
+           - The contents of your clipboard are now the raw XML contents of the file.
+           - You can paste these contents into a new document in Notepad++, and save it to a known location (or directly to the `userDefineLangs` folder in step 2)
+   - Do not just right click to try to download the file from either the [`UDL list`](./udl-list.md) or the [directory listing on GitHub](https://github.com/notepad-plus-plus/userDefinedLanguages/tree/master/UDLs), as either of those right-click actions will download the GitHub web page for that file (which HTML, and _not_ the UDL's XML file and will _not_ work).
+2. Import the file by placing the file in your `userDefineLangs` folder.  
+    - You can use Notepad++'s **Language > User Defined Language > Open User Defined Language folder...** menu entry to easily find the right folder to place your XML file
+    - It is alternately possible to use the **User Defined Language** dialog box and click **Import**, but that method is the "old way" and is no longer recommended: it makes it harder to maintain (because it puts all UDLs in a single file, instead of using a separate file for each UDL), so it is no longer recommended.
+    - More details of what those steps entail can be found in the ["Import a UDL" section](https://npp-user-manual.org/docs/user-defined-language-system/#import-a-udl) of the official documentation.
+3. Restart Notepad++
+    - Without this restart, Notepad++ will not know about the new UDL.
+4. If the UDL author provided an autoCompletion XML file for that UDL, you may download it from the `autoCompletions` folder of the repository (using similar download procedure as described in step 1 above), and put it in a file in the `autoCompletion\` sub-folder of your Notepad++ installation directory.  More details can be found in the online User Manual in the ["autoCompletion"](https://npp-user-manual.org/docs/auto-completion/) and ["configuration files details"](https://npp-user-manual.org/docs/config-files/#other-configuration-files) sections.
+5. If the UDL author provided an sample file that uses that UDL, you may download that from the `UDL-samples` folder of the repository.  If you open that sample in Notepad++ after the restart from step 3.
 
 ## Submitting your UDL to the Collection
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://github.com/notepad-plus-plus/userDefinedLanguages/blob/master/udl-list.m
 
 For now, you have to manually install a new User Defined Language.
 
-1. Use Notepad++'s **Language > User Defined Language > Open User Defined Language folder...** menu entry to easily find the right `userDefineLangs\` folder to place your UDL definition file
+1. Use Notepad++'s **Language > User Defined Language > Open User Defined Language folder...** menu entry to easily find the right `userDefineLangs\` folder to place your UDL definition file.  (You can copy the path from the file Explorer location bar, for pasting into the **Save As** dialog in step 2)
 2. Download the XML file from the [`UDL list`](./udl-list.md) of this Collection.
    - From the [`UDL list`](./udl-list.md), click on the name of the file.
    - From the file's page, use the button labled "Raw" to open the source of the UDL.  From that raw file, you can either 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For now, you have to manually install a new User Defined Language.
 3. Restart Notepad++
     - Without this restart, Notepad++ will not know about the new UDL.
 4. If the UDL author provided an autoCompletion XML file for that UDL, you may download it from the `autoCompletions` folder of the repository (using similar download procedure as described in step 2 above), and put it in a file in the `autoCompletion\` sub-folder of your Notepad++ installation directory.  More details can be found in the online User Manual in the ["autoCompletion"](https://npp-user-manual.org/docs/auto-completion/) and ["configuration files details"](https://npp-user-manual.org/docs/config-files/#other-configuration-files) sections.
-5. If the UDL author provided an sample file that uses that UDL, you may download that from the `UDL-samples` folder of the repository.  If you open that sample in Notepad++ after the restart from step 3.
+5. If the UDL author provided an sample file that uses that UDL, you may download that from the `UDL-samples` folder of the repository.  If you open that sample in Notepad++ after the restart from step 3, it should apply the UDL highlighting.
 
 ## Submitting your UDL to the Collection
 

--- a/README.md
+++ b/README.md
@@ -14,27 +14,19 @@ https://github.com/notepad-plus-plus/userDefinedLanguages/blob/master/udl-list.m
 
 For now, you have to manually install a new User Defined Language.
 
-1. Download the XML file from the [`UDL list`](./udl-list.md) of this Collection.
+1. Use Notepad++'s **Language > User Defined Language > Open User Defined Language folder...** menu entry to easily find the right `userDefineLangs\` folder to place your UDL definition file
+2. Download the XML file from the [`UDL list`](./udl-list.md) of this Collection.
    - From the [`UDL list`](./udl-list.md), click on the name of the file.
-   - From the file's page, there are two buttons (the "Raw" button on the left, or the double-square icon farther right): either of these buttons can be used to get the actual XML contents, but they behave slightly differently
-       <br>![image](https://user-images.githubusercontent.com/17455758/185504202-754541f7-ee6f-4e77-9a6b-2338448e0dfa.png)
-       - Choice 1: If you click on the button on the left, it will open up a plain-text page in the web browser, which shows the raw XML text for the UDL.
-           <br>![image](https://user-images.githubusercontent.com/17455758/193082422-d9c68744-c840-44c4-9e08-85f93985c960.png)
-           - From the resulting screen, you can either 
-               - copy the text, and paste it into a new file in Notepad++, and save it as an XML file to a known location (or directly to the `userDefineLangs` folder in step 2)
-               - or you can use your browser's **Right Click > Save As...** feature to save it in a known location (or directly to the `userDefineLangs` folder in step 2)
-       - Choice 2: If you click on the button on the right, the raw contents will be in the clipboard
-           <br>Pressing this icon ![image](https://user-images.githubusercontent.com/17455758/193082624-c67b4c77-35bd-4386-9d83-b882e0208565.png) will make it process briefly, then become this new icon ![image](https://user-images.githubusercontent.com/17455758/193084173-b36a8d5d-f057-4d89-98a8-c98e8a7f331d.png)
-           - The contents of your clipboard are now the raw XML contents of the file.
-           - You can paste these contents into a new document in Notepad++, and save it to a known location (or directly to the `userDefineLangs` folder in step 2)
-   - Do not just right click to try to download the file from either the [`UDL list`](./udl-list.md) or the [directory listing on GitHub](https://github.com/notepad-plus-plus/userDefinedLanguages/tree/master/UDLs), as either of those right-click actions will download the GitHub web page for that file (which HTML, and _not_ the UDL's XML file and will _not_ work).
-2. Import the file by placing the file in your `userDefineLangs` folder.  
-    - You can use Notepad++'s **Language > User Defined Language > Open User Defined Language folder...** menu entry to easily find the right folder to place your XML file
-    - It is alternately possible to use the **User Defined Language** dialog box and click **Import**, but that method is the "old way" and is no longer recommended: it makes it harder to maintain (because it puts all UDLs in a single file, instead of using a separate file for each UDL), so it is no longer recommended.
-    - More details of what those steps entail can be found in the ["Import a UDL" section](https://npp-user-manual.org/docs/user-defined-language-system/#import-a-udl) of the official documentation.
+   - From the file's page, use the button labled "Raw" to open the source of the UDL.  From that raw file, you can either 
+       <br>![image](https://user-images.githubusercontent.com/17455758/193082422-d9c68744-c840-44c4-9e08-85f93985c960.png)
+       <br>From that raw file, you can either:
+       - you can use your browser's **Right Click > Save As...** feature to save the raw XML file to the `userDefineLangs\` folder found in step 1
+       - copy the text of the file's contents, and paste it into a new file in Notepad++, and save it as an XML file to the `userDefineLangs\` folder found in step 1
+   - **Warning:** Do not just right click to try to download the file from either the [`UDL list`](./udl-list.md) or the [directory listing on GitHub](https://github.com/notepad-plus-plus/userDefinedLanguages/tree/master/UDLs) links, as either of those right-click actions will download the GitHub web page for that file (which HTML, and _not_ the UDL's XML file and will _not_ work).
+   - Alternatives to step 2 can be found in the ["Import a UDL" section](https://npp-user-manual.org/docs/user-defined-language-system/#import-a-udl) of the official online user manual.  But this version here is the easiest for those who haven't worked much with UDLs or GitHub.
 3. Restart Notepad++
     - Without this restart, Notepad++ will not know about the new UDL.
-4. If the UDL author provided an autoCompletion XML file for that UDL, you may download it from the `autoCompletions` folder of the repository (using similar download procedure as described in step 1 above), and put it in a file in the `autoCompletion\` sub-folder of your Notepad++ installation directory.  More details can be found in the online User Manual in the ["autoCompletion"](https://npp-user-manual.org/docs/auto-completion/) and ["configuration files details"](https://npp-user-manual.org/docs/config-files/#other-configuration-files) sections.
+4. If the UDL author provided an autoCompletion XML file for that UDL, you may download it from the `autoCompletions` folder of the repository (using similar download procedure as described in step 2 above), and put it in a file in the `autoCompletion\` sub-folder of your Notepad++ installation directory.  More details can be found in the online User Manual in the ["autoCompletion"](https://npp-user-manual.org/docs/auto-completion/) and ["configuration files details"](https://npp-user-manual.org/docs/config-files/#other-configuration-files) sections.
 5. If the UDL author provided an sample file that uses that UDL, you may download that from the `UDL-samples` folder of the repository.  If you open that sample in Notepad++ after the restart from step 3.
 
 ## Submitting your UDL to the Collection


### PR DESCRIPTION
makes it more clear that "Raw" and "Copy Raw Contents" are two separate buttons with two different behaviors, though both will work.

closes #123