### PR TITLE
Add a new version of SubStation Alpha Subtitles (ASS)

### DIFF
--- a/UDLs/Substation_alpha_subtitles_byJackyHE.xml
+++ b/UDLs/Substation_alpha_subtitles_byJackyHE.xml
@@ -1,0 +1,67 @@
+<!--//
+ASS UDL by Jacky HE
+//-->
+<NotepadPlus>
+    <UserLang name="SubStation Alpha Subtitles (ASS)" ext="ass ssa" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="1" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="yes" Keywords4="no" Keywords5="yes" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00; 01 02((EOL)) 03 04</Keywords>
+            <Keywords name="Numbers, prefix1">=</Keywords>
+            <Keywords name="Numbers, prefix2">&amp;H</Keywords>
+            <Keywords name="Numbers, extras1">A B C D E F a b c d e f C</Keywords>
+            <Keywords name="Numbers, extras2">A B C D E F a b c d e f C</Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2">&amp;</Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1">{ } ( ) , : \an \distort \rnd \1vc \2vc \3vc \4vc \1img \2img \3img \4img \mover \move1 \move2 \move3 \move4 \jitter \movevc \fad \fscx \fscy \fsvp \frs \fsc \fsp \xbord \ybord \xshad \yshad \fsp \fs \fn \alpha \1c \2c \3c \4c \1a \2a \3a \4a \pos \move \fade \fad \org \shad \bord \blur \clip \iclip \be \frx \fry \frz \fax \fay \pbo \fr \fe \kf \ko \kt \K \a \n \N \h \i \b \u \s \c \a \k \q \r \t \p \z</Keywords>
+            <Keywords name="Operators2">m b l s c n p</Keywords>
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">&quot;Title&quot; &quot;ScriptType&quot; &quot;WrapStyle&quot; &quot;ScaledBorderAndShadow&quot; &quot;YCbCr Matrix&quot; &quot;PlayResX&quot; &quot;PlayResY&quot; &quot;Original Script&quot; &quot;Original Translation&quot; &quot;Original Timing&quot; &quot;Original Editing&quot; &quot;Synch Point&quot; &quot;Script Updated By&quot; &quot;Update Details&quot; &quot;Script Type&quot; &quot;Collisions&quot; &quot;Timer&quot; &quot;WrapStyle&quot; &quot;Export Encoding&quot; &quot;Audio File&quot; &quot;Video File&quot; &quot;Video AR Mode&quot; &quot;Video AR Value&quot; &quot;Video Zoom Percent&quot; &quot;Scroll Position&quot; &quot;Active Line&quot; &quot;Video Position&quot;</Keywords>
+            <Keywords name="Keywords2">&quot;[Script Info]&quot; &quot;[V4+ Styles]&quot; &quot;[Events]&quot; &quot;[Aegisub Extradata]&quot; &quot;[Graphics]&quot; &quot;[Fonts]&quot; &quot;[Aegisub Project Garbage]&quot;</Keywords>
+            <Keywords name="Keywords3">&quot;Dialogue:&quot; &quot;Format:&quot; &quot;Comment:&quot; &quot;Style:&quot; &quot;Data:&quot; &quot;Picture:&quot; &quot;Sound:&quot; &quot;Movie:&quot; &quot;Command:&quot;</Keywords>
+            <Keywords name="Keywords4"></Keywords>
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00 01 02 03Comment 04 05((EOL)) 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="728086" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="728086" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="008282" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="8080FF" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="400080" bgColor="FFFFFF" fontStyle="5" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="FF8000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="FF0080" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000080" bgColor="FF0000" fontStyle="4" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000080" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000080" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000080" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="4E009B" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="333333" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="333333" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="333333" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="8000FF" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="585858" bgColor="FFFFFF" fontStyle="2" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -1818,6 +1818,14 @@
 			"author": "Andrew Miller <mailto:A.J.Miller@bcs.org.uk>"
 		},
 		{
+			"id-name": "Substation_alpha_subtitles_by_JackyHE",
+			"display-name": "SubStation Alpha Subtitles (ASS)",
+			"version": "Sun, 19 Mar 2022 15:00:48 GMT",
+			"repository": "",
+			"description": "Substation Alpha format",
+			"author": "Jacky HE <mailto:ihkk.nb@gmail.com>"
+		},
+		{
 			"id-name": "Susan_byMahderGebremedhin",
 			"display-name": "Susan",
 			"version": "Sun, 03 Jul 2011 09:03:22 GMT",

--- a/udl-list.json
+++ b/udl-list.json
@@ -1821,7 +1821,6 @@
 			"id-name": "Substation_alpha_subtitles_by_JackyHE",
 			"display-name": "SubStation Alpha Subtitles (ASS)",
 			"version": "Sun, 19 Mar 2022 15:00:48 GMT",
-			"repository": "",
 			"description": "Substation Alpha format",
 			"author": "Jacky HE <mailto:ihkk.nb@gmail.com>"
 		},

--- a/udl-list.md
+++ b/udl-list.md
@@ -121,7 +121,7 @@
 | [IBM Net.Data](./UDLs/Net.Data-IBM_byMarkus.xml) | IBM Net.Data | Markus |
 | [IceBreak RPG](./UDLs/IceBreak-RPG_byNielsLiisberg.xml) | IceBreak RPG | Niels Liisberg |
 | [Icon](./UDLs/Icon_byOlegBakharev.xml) | Icon | Oleg Bakharev |
-| [IFC step](https://github.com/araccaine/npplusplus-udl-ifc/raw/main/ifc_StepPhysicalFile_StandardDesign.xml) | IFC step physical file (.ifc) | [araccaine](https://github.com/araccaine)
+| [IFC step](https://github.com/araccaine/npplusplus-udl-ifc/raw/main/ifc_StepPhysicalFile_StandardDesign.xml) | IFC step physical file (.ifc) | [araccaine](https://github.com/araccaine)|
 | [Informix 4GL](./UDLs/Informix4GL_byHarryChen.xml) | Informix 4GL | Harry Chen |
 | [Interactive Data Language (.dat files)](./UDLs/ITT_IDL-dat_by-pocaracas.xml) | Interactive Data Language (.dat files) | pocaracas |
 | [Interactive Data Language (.pro files)](./UDLs/ITT_IDL-pro_byDavidHiggins.xml) | Interactive Data Language (.pro files) | David Higgins |
@@ -139,8 +139,8 @@
 | [Log for DarkMode](./UDLs/Log_darkMode_byS0UGATA.xml) | Log syntax highlighter for Dark Mode | [Sougata Bhattacharya](https://github.com/S0UGATA) |
 | [Lotus Script](./UDLs/LotusScript_byUdoJunghans.xml) | Lotus Script | Udo Junghans |
 | [Loyc Expression Syntax](./UDLs/LoycExpressionSyntax-les_Dark_byDavidPiepgrass.xml) | Loyc Expression Syntax (version for dark theme) | David Piepgrass |
-| [Magpie](./UDLs/Magpie_bySilectis.udl.xml) | This package provides syntax highlighting for the domain specific language of Mapgie, a data engineering product created by Silectis.
- | Silectis, Inc |
+| [Magpie](./UDLs/Magpie_bySilectis.udl.xml) | This package provides syntax highlighting for the domain specific language of Mapgie, a data engineering product created by Silectis.||
+| Silectis, Inc |||
 | [MEL for Autodesk Maya](./UDLs/MEL_AutodeskMaya_NeilRHagre.xml) | MEL for Autodesk Maya | Neil r. Hagre |
 | [MQL4](./UDLs/MQL4_byMichaelMargolese.xml) | MQL4 | Michael Margolese |
 | [MSC-Adams_Car](./UDLs/MSC-adams_car_by_ARRK.xml) | MSC-Adams/Car | Alexander Recknagel ARRK |
@@ -250,6 +250,7 @@
 | [Structured text for PLC programming (B&amp;R controllers)](./UDLs/StructuredText-PLC-B-R_byBradleyBaber.xml) | Structured text for PLC programming (B&amp;R controllers) | Bradley Baber |
 | [SubRip](./UDLs/SubRip_byAndreyEfremov.xml) | SubRip | Andrey Efremov |
 | [Substation Alpha format](./UDLs/SubStation_Alpha_byAndrewMiller.xml) | Substation Alpha format | Andrew Miller |
+| [Substation Alpha format](./UDLs/Substation_alpha_subtitles_byJackyHE.xml) | Substation Alpha Subtitles | Jacky HE |
 | [Susan](./UDLs/Susan_byMahderGebremedhin.xml) | Susan | Mahder Gebremedhin |
 | [System Verilog 1](./UDLs/SystemVerilog1_byKapilPatel.xml) | System Verilog 1 | Kapil Patel |
 | [SystemRDL  2.0](./UDLs/SystemRDL2_byKeithBrady.xml) | SystemRDL 2.0 | Keith Brady |
@@ -260,7 +261,7 @@
 | [Template Toolkit](./UDLs/TemplateToolkit-TT_byAndreyEfremov.xml) | Template Toolkit | Andrey Efremov |
 | [Teradata Macro Language (Term)](./UDLs/TeradataMacroLanguage-Term_byPatrickDruley.xml) | Teradata Macro Language (Term) | Patrick Druley |
 | [Teradata Tools v13](./UDLs/TeradataTools-v13_byTrevorOGrady.xml) | Teradata Tools v13 | Trevor O'Grady |
-| [Tera Term Language](./UDLs/TeraTermLanguage_allCmdsV4.xml) | Tera Term Language | Simon Buhrow
+| [Tera Term Language](./UDLs/TeraTermLanguage_allCmdsV4.xml) | Tera Term Language | Simon Buhrow|
 | [TexCnc](./UDLs/TexCnc_by-fixus971.xml) | TexCnc | fixus971 |
 | [Thrift](./UDLs/thrift_by-mail507.xml) | Thrift | mail507 |
 | [Tiny Fugue](./UDLs/TinyFugue_byYrwin.xml) | Tiny Fugue | Yrwin |
@@ -309,9 +310,9 @@
 | [YARA](./UDLs/YARA_byM0N4.xml) | YARA | [m0n4](https://github.com/m0n4) |
 | [Zig](./UDLs/zig_by-tgschultz.xml) | Zig | [tgschultz](https://github.com/tgschultz/Npp-ziglang-UDL) |
 | [ZPL](./UDLs/Zebra_Printing_Language.xml) | Zebra Printing Language | AWWOLF |
-| [Excel formulas](./UDLs/ExcelFormula_byOlivierMarche.xml) | Excel formulas | [Olivier Marché](https://github.com/OlivierMarche)
-| [Excel formulas (Dark)](./UDLs/ExcelFormula_ThemeDark_byOlivierMarche.xml) | Excel formulas (Dark theme) | [Olivier Marché](https://github.com/OlivierMarche)
-| [AMXX 1.8.3](./UDLs/AMXX_1.8.3_OciXCrom.xml) | AMXX 1.8.3 | [OciXCrom](https://github.com/OciXCrom)
+| [Excel formulas](./UDLs/ExcelFormula_byOlivierMarche.xml) | Excel formulas | [Olivier Marché](https://github.com/OlivierMarche)|
+| [Excel formulas (Dark)](./UDLs/ExcelFormula_ThemeDark_byOlivierMarche.xml) | Excel formulas (Dark theme) | [Olivier Marché](https://github.com/OlivierMarche)|
+| [AMXX 1.8.3](./UDLs/AMXX_1.8.3_OciXCrom.xml) | AMXX 1.8.3 | [OciXCrom](https://github.com/OciXCrom)|
 | [Amiga_E](./UDLs/Amiga_E_bydmcoles.xml) | Amiga E | [dmcoles](https://github.com/dmcoles) |
 | [Amiga_E_dark](./UDLs/Amiga_E_dark_bydmcoles.xml) | Amiga E (Dark version)| [dmcoles](https://github.com/dmcoles) |
 | [XC=BASIC 3](./UDLs/xcbasic3_byAlanBourke.xml) | XC=BASIC 3 syntax highlighting| Alan Bourke |


### PR DESCRIPTION
- Added a complete version of SubStation Alpha Subtitles (ASS) file highlighting, which supports ass tags.

    > There is an [existed one ](https://github.com/notepad-plus-plus/userDefinedLanguages/blob/master/UDLs/SubStation_Alpha_byAndrewMiller.xml) with poor tags support so I created a new UDL file without changing the old one.

    >More ASS tags info can be found at [ASS Override Tags
](https://aegisite.vercel.app/docs/latest/ass_tags/) 
- Fixed some wrong-formatted markdown sheets in `udl-list.md`.
