### PR TITLE
Add UDL for Simple Issue Language (SIL) from "Power Scripts for Jira" Atlassian plugin.

### DIFF
--- a/UDL-samples/SIL-Power-Scripts-for-Jira_byHaydenSingleton.sil
+++ b/UDL-samples/SIL-Power-Scripts-for-Jira_byHaydenSingleton.sil
@@ -1,0 +1,63 @@
+string k;
+
+assignee = "admin";
+reporter = assignee;
+description = "some description";
+dueDate = currentDate() + "1d";
+env = "environment";
+estimate = "2d" + "3h";
+originalEstimate = "1d 4h" + "21h";
+priority = "Critical";
+
+if(not contains(summary, "test")){
+    summary = "test " + summary;
+} else {
+    summary = "random summary assigned";
+}
+
+spent = "2d";
+updated = currentDate() - "1d";
+votes = votes + 1;
+
+//Custom fields here
+UPPG = "admin";
+
+//time interval custom field
+if(isNull(tt1)) {
+    tt1 = estimate + "1h";
+} else {
+    tt1 = tt1 + "1h";
+}
+
+//number custom field
+if(isNull(cfnumber)){
+    cfnumber = 1;
+} else {
+    cfnumber = cfnumber + 1;
+}
+
+//create routine
+k = createIssue("TSTP", "", issueType, "auto-created issue");
+%k%.votes = %k%.votes + 1;
+
+//autotransition
+autotransition(721,key);
+//or:
+//autotransition("Send report","PRJ-123");
+
+
+string boolean number integer byte date interval
+- ! ( ) * , . / : ? [ ] { } + < = >
+
+string[1]
+
+Person[0] [cat] [<cat>] <cat> <>
+
+function zero() {
+	int x = nil;
+	return 0;
+}
+
+include "math.sil"
+
+print("hello world")

--- a/UDLs/SIL-Power-Scripts-for-Jira_byHaydenSingleton.xml
+++ b/UDLs/SIL-Power-Scripts-for-Jira_byHaydenSingleton.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="SIL" ext="sil" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="yes" allowFoldOfComments="yes" foldCompact="yes" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00// 01 02 03/* 04*/</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1">+ - * / % = ; ! , .</Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open">{</Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close">}</Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">return if else NULL for while do continue break default struct</Keywords>
+            <Keywords name="Keywords2">string boolean number integer int byte date interval</Keywords>
+            <Keywords name="Keywords3">key</Keywords>
+            <Keywords name="Keywords4">null nil const key</Keywords>
+            <Keywords name="Keywords5">include function main</Keywords>
+            <Keywords name="Keywords6">logPrint isNull isNotNull print arrayAddElement arrayAddElementIfNotExist arrayDeleteElement arrayDeleteElementAt arrayDiff arrayElementExists arrayFind arrayFindBinary arrayGetElement arrayIntersect arrayKeys arrayKeySort arraysConcat arraySetElement arraySize arraySort arrayStructMap arrayStructSort arrayToSet arrayUnion excludeSubarray subarray</Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00&quot; 01\ 02&quot; 03&apos; 04\ 05&apos; 06&lt; 07 08&gt; 09[ 10 11] 12$ 13\ 14$ 15$! 16\ 17$ 18#{ 19 20} 21( 22 23)</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="C0C0C0" bgColor="FFFFFF" colorStyle="1" fontStyle="2" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="808080" bgColor="FFFFFF" colorStyle="1" fontStyle="2" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="0080C0" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="0000FF" bgColor="FFFFFF" colorStyle="1" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="0000FF" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="000000" bgColor="FFFFFF" colorStyle="1" fontStyle="2" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="0080FF" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="804040" bgColor="FFFFFF" colorStyle="1" fontStyle="3" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="0000A0" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000040" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" colorStyle="2" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="008040" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="32771" />
+            <WordsStyle name="DELIMITERS2" fgColor="008040" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="32771" />
+            <WordsStyle name="DELIMITERS3" fgColor="0000FF" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="117701887" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="117701887" />
+            <WordsStyle name="DELIMITERS5" fgColor="8080FF" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="768" />
+            <WordsStyle name="DELIMITERS6" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="768" />
+            <WordsStyle name="DELIMITERS7" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="0" nesting="117702655" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="83886095" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -3,6 +3,15 @@
 	"version": "1.0",
 	"UDLs": [
 		{
+			"id-name": "SIL-Jira-Power-Scripts_byHaydenSingleton",
+			"display-name": "SIL",
+			"version": "2023-10-19",
+			"repository": "",
+			"description": "Syntax Highlighting for Simple Issue Language (SIL) from Power Scripts for Jira and Power Actions for Jira plugins by Appfire.",
+			"author": "Hayden Singleton",
+			"homepage": "https://github.com/HaydenSingleton"
+		},
+		{
 			"id-name": "RouterOS Script",
 			"display-name": "RouterOS Script - NieL™",
 			"version": "2023-06-01",

--- a/udl-list.json
+++ b/udl-list.json
@@ -3,11 +3,11 @@
 	"version": "1.0",
 	"UDLs": [
 		{
-			"id-name": "SIL-Jira-Power-Scripts_byHaydenSingleton",
+			"id-name": "SIL-Power-Scripts-for-Jira_byHaydenSingleton",
 			"display-name": "SIL",
 			"version": "2023-10-19",
 			"repository": "",
-			"description": "Syntax Highlighting for Simple Issue Language (SIL) from Power Scripts for Jira and Power Actions for Jira plugins by Appfire.",
+			"description": "Syntax Highlighting for Simple Issue Language from Power Scripts for Jira by Appfire.",
 			"author": "Hayden Singleton",
 			"homepage": "https://github.com/HaydenSingleton"
 		},

--- a/udl-list.md
+++ b/udl-list.md
@@ -232,7 +232,7 @@
 | [SAS](./UDLs/SAS_byCathLawrence.xml) | SAS | Cath Lawrence |
 | [SAS dark style](./UDLs/SAS_StyleDark_byMatthiasBoege.xml) | SAS for dark NPP styles | Matthias B&ouml;ge |
 | [SAS light style](./UDLs/SAS_StyleLight_byMatthiasBoege.xml) | SAS for light NPP styles | Matthias B&ouml;ge |
-| [SIL](./UDLs/SIL-Jira-Power-Scripts_byHaydenSingleton.xml) | Simple Issue Language from Power Scripts for Jira by Appfire. | Hayden Singleton |
+| [SIL](./UDLs/SIL-Power-Scripts-for-Jira_byHaydenSingleton.xml) | Simple Issue Language from Power Scripts for Jira by Appfire. | Hayden Singleton |
 | [SLAX](./UDLs/SLAX_byTravisWaltz.xml) | SLAX | Travis Waltz |
 | [SPARQL 1.1](./UDLs/SPARQL-v1p1_byFranckMichel.xml) | SPARQL 1.1 | Franck Michel |
 | [SPiiPlus ACSPL+](./UDLs/SPiiPlus_ACSPL+_bySROMSE.xml) | SPiiPlus ACSPL+ | Sergio Miracco |

--- a/udl-list.md
+++ b/udl-list.md
@@ -232,7 +232,7 @@
 | [SAS](./UDLs/SAS_byCathLawrence.xml) | SAS | Cath Lawrence |
 | [SAS dark style](./UDLs/SAS_StyleDark_byMatthiasBoege.xml) | SAS for dark NPP styles | Matthias B&ouml;ge |
 | [SAS light style](./UDLs/SAS_StyleLight_byMatthiasBoege.xml) | SAS for light NPP styles | Matthias B&ouml;ge |
-| [SIL](./UDLs/SIL-Jira-Power-Scripts_byHaydenSingleton.xml) | Simple Issue Language from Power Scripts for Jira and Power Actions for Jira plugins by Appfire | Hayden Singleton |
+| [SIL](./UDLs/SIL-Jira-Power-Scripts_byHaydenSingleton.xml) | Simple Issue Language from Power Scripts for Jira by Appfire. | Hayden Singleton |
 | [SLAX](./UDLs/SLAX_byTravisWaltz.xml) | SLAX | Travis Waltz |
 | [SPARQL 1.1](./UDLs/SPARQL-v1p1_byFranckMichel.xml) | SPARQL 1.1 | Franck Michel |
 | [SPiiPlus ACSPL+](./UDLs/SPiiPlus_ACSPL+_bySROMSE.xml) | SPiiPlus ACSPL+ | Sergio Miracco |

--- a/udl-list.md
+++ b/udl-list.md
@@ -2,7 +2,6 @@
 
 | Name | Description | Author |
 |------|-------------|-------:|
-| [RouterOS Script - NieL™](./UDLs/RouterOS-Script-NieL™.xml) | Syntax for the Mikrotik RouterOS Script, it is unofficial UDL to help scripting your mikrotik. Highlighting syntax somewhat helpful of detecting error inputs | NieL™ TechSolution |
 | [6502 Assembly](./UDLs/6502Assembly_byCarlMyerholtz.xml) | ASM for 6502 | Carl Myerholtz |
 | [3GL](./UDLs/3GL_byDrezzzz.xml) | 3GL | drezzzzz |
 | [68k Assembly](./UDLs/68K_Assembly_byAmix73.xml) | 68k Assembly | Amix 73 |
@@ -226,12 +225,14 @@
 | [Rules Language](./UDLs/Rules_Language_byNimadDeshpande.xml) | Rules Language | Nimad Deshpande |
 | [Rust Language](./UDLs/Rust_byPaoloFalabella.xml) | Rust Language | [Paolo Falabella](https://github.com/pfalabella) |
 | [Robotframework](./UDLs/vkosuri_lang-robot.xml) | Robotframework with autocompletion | vkosuri |
+| [RouterOS Script - NieL™](./UDLs/RouterOS-Script-NieL™.xml) | Syntax for the Mikrotik RouterOS Script, it is unofficial UDL to help scripting your mikrotik. Highlighting syntax somewhat helpful of detecting error inputs | NieL™ TechSolution |
 | [SAP NetWeaver IdM language](./UDLs/SAP-NetWeaver-IdM-v7p1_byFrankBuchholz.xml) | SAP NetWeaver IdM language | Frank Buchholz |
 | [SAP Web Intelligence Formula Editor](./UDLs/SAP-WebIntelligenceFormula_byIvanRubil.xml) | SAP Web Intelligence Formula Editor | Ivan Rubil |
 | [SAS with pseudocode](./UDLs/SAS_withPseudocode_byJeffFoarde.xml) | SAS with pseudocode | Jeff Foarde |
 | [SAS](./UDLs/SAS_byCathLawrence.xml) | SAS | Cath Lawrence |
 | [SAS dark style](./UDLs/SAS_StyleDark_byMatthiasBoege.xml) | SAS for dark NPP styles | Matthias B&ouml;ge |
 | [SAS light style](./UDLs/SAS_StyleLight_byMatthiasBoege.xml) | SAS for light NPP styles | Matthias B&ouml;ge |
+| [SIL](./UDLs/SIL-Jira-Power-Scripts_byHaydenSingleton.xml) | Syntax Highlighting for Simple Issue Language (SIL) from Power Scripts for Jira and Power Actions for Jira plugins by Appfire | [Hayden Singleton](https://github.com/HaydenSingleton) |
 | [SLAX](./UDLs/SLAX_byTravisWaltz.xml) | SLAX | Travis Waltz |
 | [SPARQL 1.1](./UDLs/SPARQL-v1p1_byFranckMichel.xml) | SPARQL 1.1 | Franck Michel |
 | [SPiiPlus ACSPL+](./UDLs/SPiiPlus_ACSPL+_bySROMSE.xml) | SPiiPlus ACSPL+ | Sergio Miracco |

--- a/udl-list.md
+++ b/udl-list.md
@@ -232,7 +232,7 @@
 | [SAS](./UDLs/SAS_byCathLawrence.xml) | SAS | Cath Lawrence |
 | [SAS dark style](./UDLs/SAS_StyleDark_byMatthiasBoege.xml) | SAS for dark NPP styles | Matthias B&ouml;ge |
 | [SAS light style](./UDLs/SAS_StyleLight_byMatthiasBoege.xml) | SAS for light NPP styles | Matthias B&ouml;ge |
-| [SIL](./UDLs/SIL-Jira-Power-Scripts_byHaydenSingleton.xml) | Syntax Highlighting for Simple Issue Language (SIL) from Power Scripts for Jira and Power Actions for Jira plugins by Appfire | [Hayden Singleton](https://github.com/HaydenSingleton) |
+| [SIL](./UDLs/SIL-Jira-Power-Scripts_byHaydenSingleton.xml) | Simple Issue Language from Power Scripts for Jira and Power Actions for Jira plugins by Appfire | Hayden Singleton |
 | [SLAX](./UDLs/SLAX_byTravisWaltz.xml) | SLAX | Travis Waltz |
 | [SPARQL 1.1](./UDLs/SPARQL-v1p1_byFranckMichel.xml) | SPARQL 1.1 | Franck Michel |
 | [SPiiPlus ACSPL+](./UDLs/SPiiPlus_ACSPL+_bySROMSE.xml) | SPiiPlus ACSPL+ | Sergio Miracco |


### PR DESCRIPTION
SIL is used by Jira administrators to perform advanced workflow automations and customizations. The language is not supported by any existing syntax highlighting plugin I could find. 
Documentation for the language can be found here: [Power Scripts Introduction](https://appfire.atlassian.net/wiki/spaces/PSJ/pages/15481255/Power+Scripts+Introduction)

The related plugin page is here: [Power Scripts - Jira Workflow Automation](https://marketplace.atlassian.com/apps/43318/power-scripts-jira-workflow-automation)