### PR TITLE
GraphViz update Feb2024

### DIFF
--- a/UDLs/GraphViz_by-signmotion.xml
+++ b/UDLs/GraphViz_by-signmotion.xml
@@ -4,8 +4,8 @@
 -
 - @site Graphviz  > http://graphviz.org
 - @site Notepad++ > http://notepad-plus-plus.org
-- 
-- @author Andrey Syrokomskiy, signmotion@gmail.com, http://signmotion.blogspot.com
+-
+- @author Andrii Syrokomskyi, http://syrokomskyi.com
 -->
 <NotepadPlus>
     <UserLang name="Graphviz" ext="gv" udlVersion="2.1">

--- a/udl-list.json
+++ b/udl-list.json
@@ -2325,8 +2325,8 @@
 		{
 			"id-name": "GraphViz_by-signmotion",
 			"display-name": "GraphViz",
-			"version": "Sun, 26 Jan 2020 22:39:17 GMT",
-			"repository": "https://raw.githubusercontent.com/signmotion/graphviz-syntax-highlighting/master/graphviz-notepad-udl.xml",
+			"version": "Sun, 20 Feb 2024 09:59:00 GMT",
+			"repository": "https://raw.githubusercontent.com/signmotion/graphviz-syntax-highlighting/master/src/graphviz_udl.xml",
 			"description": "GraphViz",
 			"author": "signmotion",
 			"homepage": "https://github.com/signmotion/graphviz-syntax-highlighting"

--- a/udl-list.md
+++ b/udl-list.md
@@ -126,7 +126,7 @@
 | [Google Go (syntax and auto-completion)](./UDLs/go_byAnthonyStarks.xml) | [Anthony Starks](mailto:ajstarks@gmail.com) | Google Go (syntax and auto-completion) |
 | [Google Protocol Buffers](./UDLs/GoogleProtocolBuffers-GPB_byBradWehmeier.xml) | [Brad Wehmeier](mailto:bradboy57@gmail.com) | Google Protocol Buffers |
 | [GPD](https://github.com/SinghRajenM/GPD_UDL) | [Rajendra Singh](https://github.com/SinghRajenM) | UDL for GPD (Generic Printer Description) and GDL (Generic Description Language). |
-| [GraphViz](https://raw.githubusercontent.com/signmotion/graphviz-syntax-highlighting/master/graphviz-notepad-udl.xml) | [signmotion](https://github.com/signmotion/graphviz-syntax-highlighting) | GraphViz |
+| [GraphViz](https://raw.githubusercontent.com/signmotion/graphviz-syntax-highlighting/master/src/graphviz_udl.xml) | [signmotion](https://github.com/signmotion/graphviz-syntax-highlighting) | GraphViz |
 | [Gregorio](./UDLs/Gregorio_byBrotherGabriel-Marie.xml) | [Brother Gabriel-Marie](mailto:brgabriel@sspx.org) | Gregorio |
 | [Groovy](./UDLs/Groovy_byGyrm.xml) | [gyrm](mailto:gyrm@users.sourceforge.net) | Groovy |
 | [HL7 (ChrisK variant)](./UDLs/HL7_StackOverflow-ChrisK.xml) | [Chris K](https://stackoverflow.com/a/11037142/5508606) | HL7 |


### PR DESCRIPTION
https://github.com/notepad-plus-plus/userDefinedLanguages/actions/runs/8064965334 failed, so I updated the link to reflect signmotion's most recent repo structure/naming.