### PR TITLE
Icinga DSL UDL

### DIFF
--- a/UDL-samples/Icinga_DSL_by_robweber.conf
+++ b/UDL-samples/Icinga_DSL_by_robweber.conf
@@ -1,0 +1,147 @@
+/*
+* This is an example file of the Icinga DSL language
+* Examples pulled from the Icinga Documentation: https://icinga.com/docs/icinga-2/latest/doc/04-configuration/
+*/
+
+template Host "generic-host" {
+  max_check_attempts = 5
+  check_interval = 1m
+  retry_interval = 30s
+
+  check_command = "hostalive"
+}
+
+template Service "generic-service" {
+  max_check_attempts = 3
+  check_interval = 1m
+  retry_interval = 30s
+}
+
+object CheckCommand "http" {
+  command = [ PluginDir + "/check_http" ]
+
+  arguments = {
+    "-H" = "$http_vhost$"
+    "-I" = "$http_address$"
+    "-u" = "$http_uri$"
+    "-p" = "$http_port$"
+    "-S" = {
+      set_if = "$http_ssl$"
+    }
+    "--sni" = {
+      set_if = "$http_sni$"
+    }
+    "-a" = {
+      value = "$http_auth_pair$"
+      description = "Username:password on sites with basic authentication"
+    }
+    "--no-body" = {
+      set_if = "$http_ignore_body$"
+    }
+    "-r" = "$http_expect_body_regex$"
+    "-w" = "$http_warn_time$"
+    "-c" = "$http_critical_time$"
+    "-e" = "$http_expect$"
+  }
+
+  vars.http_address = "$address$"
+  vars.http_ssl = false
+  vars.http_sni = false
+}
+
+object Host NodeName {
+  /* Import the default host template defined in `templates.conf`. */
+  import "generic-host"
+
+  /* Specify the address attributes for checks e.g. `ssh` or `http`. */
+  address = "127.0.0.1"
+  address6 = "::1"
+
+  /* Set custom variable `os` for hostgroup assignment in `groups.conf`. */
+  vars.os = "Linux"
+
+  /* Define http vhost attributes for service apply rules in `services.conf`. */
+  vars.http_vhosts["http"] = {
+    http_uri = "/"
+  }
+  /* Uncomment if you've successfully installed Icinga Web 2. */
+  //vars.http_vhosts["Icinga Web 2"] = {
+  //  http_uri = "/icingaweb2"
+  //}
+
+  /* Define disks and attributes for service apply rules in `services.conf`. */
+  vars.disks["disk"] = {
+    /* No parameters. */
+  }
+  vars.disks["disk /"] = {
+    disk_partitions = "/"
+  }
+
+  /* Define notification mail attributes for notification apply rules in `notifications.conf`. */
+  vars.notification["mail"] = {
+    /* The UserGroup `icingaadmins` is defined in `users.conf`. */
+    groups = [ "icingaadmins" ]
+  }
+}
+
+apply Service "load" {
+  import "generic-service"
+
+  check_command = "load"
+
+  /* Used by the ScheduledDowntime apply rule in `downtimes.conf`. */
+  vars.backup_downtime = "02:00-03:00"
+
+  assign where host.name == NodeName
+}
+
+apply Service "ssh" {
+  import "generic-service"
+
+  check_command = "ssh"
+
+  assign where host.address && host.vars.os == "Linux"
+}
+
+object User "icingaadmin" {
+  import "generic-user"
+
+  display_name = "Icinga 2 Admin"
+  groups = [ "icingaadmins" ]
+
+  email = "icinga@localhost"
+}
+
+object UserGroup "icingaadmins" {
+  display_name = "Icinga 2 Admin Group"
+}
+
+apply Notification "mail-icingaadmin" to Host {
+  import "mail-host-notification"
+
+  user_groups = host.vars.notification.mail.groups
+  users = host.vars.notification.mail.users
+
+  assign where host.vars.notification.mail
+}
+
+apply Notification "mail-icingaadmin" to Service {
+  import "mail-service-notification"
+
+  user_groups = host.vars.notification.mail.groups
+  users = host.vars.notification.mail.users
+
+  assign where host.vars.notification.mail
+}
+
+object HostGroup "linux-servers" {
+  display_name = "Linux Servers"
+
+  assign where host.vars.os == "Linux"
+}
+
+object HostGroup "windows-servers" {
+  display_name = "Windows Servers"
+
+  assign where host.vars.os == "Windows"
+}

--- a/UDLs/Icinga_DSL_by_robweber.xml
+++ b/UDLs/Icinga_DSL_by_robweber.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="Icinga DSL" ext="conf" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00// 01 02 03/* 04*/</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1">ms s m h d</Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1">$ ! ~ + - &amp; * / %</Keywords>
+            <Keywords name="Operators2">in &amp;&amp; == = =&gt; += &lt;&lt; &gt;&gt; &lt; &gt; &lt;= &gt;= ^ | || ?</Keywords>
+            <Keywords name="Folders in code1, open">{</Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close">}</Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">apply&#x000D;&#x000A;template&#x000D;&#x000A;object&#x000D;&#x000A;Comment&#x000D;&#x000A;Downtime&#x000D;&#x000A;Dependency&#x000D;&#x000A;Notification&#x000D;&#x000A;Service&#x000D;&#x000A;HostGroup&#x000D;&#x000A;ScheduledDowntime&#x000D;&#x000A;Host&#x000D;&#x000A;CheckCommand&#x000D;&#x000A;ServiceGroup&#x000D;&#x000A;HostGroup&#x000D;&#x000A;ApiUser&#x000D;&#x000A;ApiListener&#x000D;&#x000A;Dependency&#x000D;&#x000A;Endpoint&#x000D;&#x000A;EventCommand&#x000D;&#x000A;NotificationCommand&#x000D;&#x000A;ScheduledDowntime&#x000D;&#x000A;TimePeriod&#x000D;&#x000A;User&#x000D;&#x000A;UserGroup&#x000D;&#x000A;&quot;to Host&quot;&#x000D;&#x000A;&quot;to Service&quot;&#x000D;&#x000A;&quot;assign where&quot;&#x000D;&#x000A;&quot;ignore where&quot;&#x000D;&#x000A;for (&#x000D;&#x000A;namespace&#x000D;&#x000A;if&#x000D;&#x000A;while&#x000D;&#x000A;function</Keywords>
+            <Keywords name="Keywords2"></Keywords>
+            <Keywords name="Keywords3"></Keywords>
+            <Keywords name="Keywords4">true&#x000D;&#x000A;false&#x000D;&#x000A;null</Keywords>
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00&quot; 01 02&quot; 03$ 04 05$ 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="004080" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="008000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="FF8000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="8000FF" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="004080" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="004080" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="0000FF" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="FF0000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="2" />
+            <WordsStyle name="DELIMITERS2" fgColor="FF0000" bgColor="FFFFFF" fontStyle="4" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -926,6 +926,15 @@
 			"author": "Niels Liisberg <mailto:nli@system-method.com>"
 		},
 		{
+			"id-name": "Icinga_DSL_by_robweber",
+			"display-name": "Icinga DSL",
+			"version": "2024-03-25",
+			"repository": "",
+			"description": "Icinga DSL for use with Icinga2 monitoring solution",
+			"author": "robweber",
+			"homepage": "https://github.com/robweber"
+		},
+		{
 			"id-name": "Icon_byOlegBakharev",
 			"display-name": "Icon",
 			"version": "Sun, 05 Aug 2012 13:52:40 GMT",


### PR DESCRIPTION
This UDL adds syntax highlighting for the Icinga DSL syntax uses by the Icinga2 monitoring system. This is similar to Nagios but with a different configuration syntax (hence the different UDL). 

Examples of the syntax for comparison can be found in the [Icinga Object Type Reference](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/) and [Language Reference](https://icinga.com/docs/icinga-2/latest/doc/17-language-reference/).  The example file is a good reference for the most common items found in a typical installation.  