### PR TITLE
Update the Vim script functionList

### DIFF
--- a/Test/functionList/Vimscript_by_rdipardo/unitTest.expected.result
+++ b/Test/functionList/Vimscript_by_rdipardo/unitTest.expected.result
@@ -1,1 +1,1 @@
-{"leaves":["build_go_files"],"root":"unitTest"}
+{"leaves":["build_go_files","F","Baz","g","H","foo","namespaced#function","Another#namespaced#function"],"root":"unitTest"}

--- a/UDL-samples/Vimscript_by_rdipardo.vimrc
+++ b/UDL-samples/Vimscript_by_rdipardo.vimrc
@@ -87,4 +87,38 @@ func! s:build_go_files() abort
   endif
 endfunc
 
+"""""""""""""""""""
+"      Tests      "
+"""""""""""""""""""
+function F(x)
+  echom 'Pass'
+endfunction
+
+func Baz(x, y)
+  echom 'Pass'
+endfunc
+
+function! s:g(x)
+  echom 'Pass'
+endfunction
+
+function! s:H(x)
+  echom 'Pass'
+endfunction
+
+func! s:foo(x, y)
+  echom 'Pass'
+endfunc
+
+func! namespaced#function(...)
+  echom 'Pass'
+endfunc
+
+func! Another#namespaced#function(...)
+  echom 'Pass'
+endfunc
+
+" func IgnoreMe()
+" endfunc
+
 " vim: syntax=vim

--- a/functionList/Vimscript_by_rdipardo.xml
+++ b/functionList/Vimscript_by_rdipardo.xml
@@ -13,15 +13,15 @@
 		<!-- based on rules https://learnvim.irian.to/vimscript/vimscript_functions -->
 
 		<parser
-			id="vimscript_fuunc"
+			id="vimscript_func"
 			displayName="Vim Script"
-			commentExpr="(?-s:#.*)"
+			commentExpr="(?-s:&quot;.*)"
 		>
 			<function
-				mainExpr="^\h*func(tion)?!?\h+(?-i:\u|s:\l?)\w+"
+				mainExpr="^\h*func(tion)?!?\h+(?-i:\u|(s:(?!\w+#)|(\w+#)+)\l?)(#?\w)*"
 			>
 				<functionName>
-					<nameExpr expr="^\h*func(tion)?!?\h+\K(?-i:\u|s:\K\l?)\w+" />
+					<nameExpr expr="^\h*func(tion)?!?\h+\K(?-i:\u|(s:\K|(\w+#)+)\l?)(#?\w)*" />
 				</functionName>
 			</function>
 		</parser>


### PR DESCRIPTION
#### `/NotepadPlus/functionList/parser [@commentExpr]`

 * the UDL targets "legacy" Vim script, in which comments begin with a double quote ("), not a hash (#) as in Vim9 script [^1]

#### `/NotepadPlus/functionList/parser/function [@mainExpr]`, `/NotepadPlus/functionList/parser/function/functionName [@nameExpr]`


 * allow "namespaced" functions like those encountered in many Vim plugins. The conventional pattern is `<vim_script_file_name>#<func_name>`, assuming `<vim_script_file_name>` can be found on the file system. Any sub-directories must also be part of the name, similar to a Java package, e.g.,
    ```
    <root_dir>#<sub_dir>#<vim_script_file_name>#<func_name>
    ```
   A namespaced function cannot be qualified with `s:` because the auto-generated script id of a "private" function makes the name differ from the name of the file or directory on disk

 * end the function name pattern with `\w*` instead of `\w+` to allow single-letter function names

  [^1]: https://vimhelp.org/vim9.txt.html#vim9-differences