### PR TITLE
OsirisV4 for Osiris-based scripts featured in Glasses 4.1.1 (Larian Studio© official modding toolkit)

### DIFF
--- a/UDLs/OsirisNotepadSetup.xml
+++ b/UDLs/OsirisNotepadSetup.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="OsirisV4" ext=".osx" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="yes" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00// 01 02 03 04</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2">_</Keywords>
+            <Keywords name="Numbers, extras1">a b c d e f -</Keywords>
+            <Keywords name="Numbers, extras2">a b c d e f</Keywords>
+            <Keywords name="Numbers, suffix1">- </Keywords>
+            <Keywords name="Numbers, suffix2">,</Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1"></Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open">INIT:</Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close">ENDI</Keywords>
+            <Keywords name="Folders in code2, open">KB:</Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close">KBI</Keywords>
+            <Keywords name="Folders in comment, open">REGION</Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close">END_REGION</Keywords>
+            <Keywords name="Keywords1">INIT&#x000D;&#x000A;KB&#x000D;&#x000A;EXIT</Keywords>
+            <Keywords name="Keywords2">NOT</Keywords>
+            <Keywords name="Keywords3">IF AND THEN PROC</Keywords>
+            <Keywords name="Keywords4">CHARACTER GUIDSTRING ITEM TRIGGER TAG</Keywords>
+            <Keywords name="Keywords5">GLO</Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00DB_ 01 02; 03( 04(REAL) 04(INTEGER) 04(TAG) 04(ITEM) 04(ITEMROOT) 04(ROOT) 05) 06(C 07 08R) 09&quot; 10 11&quot; 12(TR 13 14R) 15(G 16 17G) 18(FL 19 20G) 21PROC_ 22 23;</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="008000" bgColor="FFFFFF" fontStyle="2" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="FF0000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="FF0080" bgColor="FFFFFF" fontStyle="5" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="804000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="400040" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="FF0080" bgColor="FFFFFF" fontStyle="5" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="FF0080" bgColor="FFFFFF" fontStyle="5" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="FF8040" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="408080" bgColor="FFFFFF" fontStyle="1" nesting="67141502" />
+            <WordsStyle name="DELIMITERS2" fgColor="000080" bgColor="FFFFFF" fontStyle="0" nesting="67118076" />
+            <WordsStyle name="DELIMITERS3" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="1" nesting="15611" />
+            <WordsStyle name="DELIMITERS4" fgColor="800000" bgColor="FFFFFF" fontStyle="1" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="1" nesting="67132911" />
+            <WordsStyle name="DELIMITERS6" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="1" nesting="13" />
+            <WordsStyle name="DELIMITERS7" fgColor="FF00FF" bgColor="FFFFFF" fontStyle="1" nesting="117465087" />
+            <WordsStyle name="DELIMITERS8" fgColor="008040" bgColor="FFFFFF" fontStyle="1" nesting="67116159" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -3007,6 +3007,15 @@
             "description": "Zig",
             "author": "tgschultz",
             "homepage": "https://github.com/tgschultz/Npp-ziglang-UDL"
+        },
+		{
+            "id-name": "OsirisNotepadSetup",
+            "display-name": "OsirisV4",
+            "version": "2025-Feb-04",
+            "repository": "",
+            "description": "Osiris Script - Larian Studios©. Also format any UUIDs & GUIDs as numbers. UUIDs start with '_' and are separated by a comma, with '-' separating each hex value.",
+            "author": "Mikiish",
+            "homepage": "https://github.com/Mikiish/Mod_Data_Backup/blob/main/udl-list.json"
         }
     ]
 }


### PR DESCRIPTION
Adding Osiris support for Notepad++.  Osiris is a scripting language invented by Larian Studios© when developping their games Divinity: Original Sin series and Baldur's Gate 3. Because this language is a bit special (event-driven declarative and rule-based i.e. it's Logical Programming some kind of modern Prolog) I couldn't find any existing language that would match and decided to create it with my negative knowledge in UDL.

I believe people may find interest in this formating, especially because it flag UUIDs as numbers using the following formating :
\_**abcdef01-2345-6789-abcd-ef0123456789**, with each UUID starting with '_' and ending with either not a number or a comma. UUIDs are in common use in many languages and not always automatically formated in Notepad++ so it's pretty useful. Usefull for any wierd rule-based language as well.

More info see https://mod.io/g/baldursgate3/r/osirisv4-notepad-udl-v21-setup-for-osiris-stories