### PR TITLE
Improve Google Protocol Buffers to recognize stream keyword

### DIFF
--- a/UDLs/GoogleProtocolBuffers-GPB_byBradWehmeier.xml
+++ b/UDLs/GoogleProtocolBuffers-GPB_byBradWehmeier.xml
@@ -15,16 +15,16 @@
             <Keywords name="Numbers, range"></Keywords>
             <Keywords name="Operators1">; [ ] =</Keywords>
             <Keywords name="Operators2"></Keywords>
-            <Keywords name="Folders in code1, open">{</Keywords>
+            <Keywords name="Folders in code1, open">{ (</Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>
-            <Keywords name="Folders in code1, close">}</Keywords>
+            <Keywords name="Folders in code1, close">} )</Keywords>
             <Keywords name="Folders in code2, open"></Keywords>
             <Keywords name="Folders in code2, middle"></Keywords>
             <Keywords name="Folders in code2, close"></Keywords>
             <Keywords name="Folders in comment, open"></Keywords>
             <Keywords name="Folders in comment, middle"></Keywords>
             <Keywords name="Folders in comment, close"></Keywords>
-            <Keywords name="Keywords1">message enum required optional repeated option default packed true false import extend extensions package service rpc returns</Keywords>
+            <Keywords name="Keywords1">message enum required optional repeated option default packed true false import extend extensions package service rpc returns stream</Keywords>
             <Keywords name="Keywords2">double float int32 int64 uint32 uint64 sint32 sint64 fixed32 fixed64 sfixed32 sfixed64 bool string bytes</Keywords>
             <Keywords name="Keywords3"></Keywords>
             <Keywords name="Keywords4"></Keywords>


### PR DESCRIPTION
As seen in this example, the `stream` keyword should be highlighted:

```protobuf
service TestService {
    rpc Test(TestRequest) returns (stream TestResponse);
}
```

Adding `stream` to keywords ensures it is. In addition, brackets `()` have to be added to folding characters to prevent them being recognized as part of the keyword.