### PR TITLE
force Python Version and bump JsonSchema version

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -23,22 +23,10 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v6
 
-    - name: Debug Python version
-      working-directory: .
-      run: |
-          (get-command python.exe).Path
-          python --version
-
     - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
         python-version: '3.13' # Uses the latest patch version of the given
-
-    - name: Debug Python version
-      working-directory: .
-      run: |
-          (get-command python.exe).Path
-          python --version
 
     - name: Install python modules
       working-directory: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema==4.25.1
+jsonschema==4.26.0
 lxml==6.0.2
 pywin32==311
 requests==2.32.5


### PR DESCRIPTION
per #362, need to bump jsonschema, but the windows-latest is apparently using Python 3.9.x, which isn't new enough for jsonschema 4.26.0.  

use actions/setup-python to force 3.13, which is new enough to also bump jsonschema to 4.26.0