### PR TITLE
Add HUML UDL (light + dark variants)

### DIFF
--- a/UDL-samples/HUML.Huml-Lang.huml
+++ b/UDL-samples/HUML.Huml-Lang.huml
@@ -1,0 +1,142 @@
+%HUML v0.2
+
+# HUML v0.2 syntax-highlight showcase
+# Copy this file to UDL-samples/HUML.Huml-Lang.huml in the userDefinedLanguages fork.
+
+# ── Scalar values ─────────────────────────────────────────────────────────────
+
+scalars::
+  string_value: "Hello, HUML!"
+  escaped_string: "Tab:\there  Newline:\n  Backslash: \\"
+  empty_string: ""
+  boolean_true: true
+  boolean_false: false
+  null_value: null
+
+# ── Special numeric keywords ───────────────────────────────────────────────────
+
+specials::
+  nan_value: nan
+  inf_value: inf
+  neg_inf: -inf
+  case_variants::
+    upper_true: TRUE
+    mixed_null: Null
+    upper_nan: NaN
+
+# ── Numbers ───────────────────────────────────────────────────────────────────
+
+numbers::
+  integer_decimal: 42
+  integer_negative: -7
+  integer_zero: 0
+  integer_separated: 1_000_000
+  integer_large: 9_223_372_036_854_775_807
+  float_simple: 3.14159
+  float_negative: -78.90
+  float_scientific: 1.23e10
+  float_neg_exp: 4.56e-7
+  float_zero: 0.0
+  hex: 0xDEADBEEF
+  octal: 0o777
+  binary: 0b1010101
+  hex_upper: 0XDEADBEEF
+  hex_lowercase: 0xcafe
+
+# ── Multiline string (triple-quoted) ─────────────────────────────────────────
+
+haiku: """
+  An old silent pond
+  A frog jumps into the pond
+  Splash of silence
+"""
+
+indented_poem: """
+  Line one at base indent
+    Line two indented further
+      Line three deepest
+    Back to two
+  Back to one
+"""
+
+# ── Quoted keys ───────────────────────────────────────────────────────────────
+
+quoted_keys::
+  "key with spaces": "spaced value"
+  "123numeric_start": "numeric key"
+  "key-with-dashes": "dashed value"
+  "key.with.dots": "dotted value"
+  "special!@#$": "special chars"
+  "": "empty key"
+  "true": "boolean as key"
+  "null": "null as key"
+
+# ── Empty collections ─────────────────────────────────────────────────────────
+
+empty_list:: []
+empty_dict:: {}
+
+# ── Inline collections ────────────────────────────────────────────────────────
+
+inline::
+  list_integers:: 1, 2, 3, 4, 5
+  list_strings:: "red", "green", "blue"
+  list_mixed:: 1, "two", true, null, 3.14
+  dict_simple:: x: 1, y: 2, z: 3
+  dict_strings:: name: "Alice", role: "admin"
+  dict_mixed:: count: 42, active: true, label: "main"
+
+# ── Block list ────────────────────────────────────────────────────────────────
+
+primes::
+  - 2
+  - 3
+  - 5
+  - 7
+  - 11
+
+# ── List of dicts ─────────────────────────────────────────────────────────────
+
+users::
+  - ::
+    name: "Alice"
+    admin: true
+    score: 9_500
+  - ::
+    name: "Bob"
+    admin: false
+    score: 7_200
+  - :: name: "Carol", admin: true, score: 8_800
+
+# ── Nested blocks ─────────────────────────────────────────────────────────────
+
+server::
+  host: "localhost"
+  port: 8080
+  tls: true
+  timeouts::
+    connect_ms: 5_000
+    read_ms: 30_000
+  allowed_origins:: "https://example.com", "https://api.example.com"
+
+# ── Inline comments ───────────────────────────────────────────────────────────
+
+comments::
+  value_with_comment: 42 # end-of-line comment
+  string_with_comment: "text" # comment after string
+  block_with_comment:: # comment after vector indicator
+    key: "value"
+
+# ── Deep nesting ──────────────────────────────────────────────────────────────
+
+deep::
+  level_one::
+    level_two::
+      level_three::
+        scalar: "reached the bottom"
+        list::
+          - "item one"
+          - ::
+            nested_key: "nested_value"
+            nested_num: 0xFF
+          - "item three"

--- a/UDLs/HUML.Huml-Lang.xml
+++ b/UDLs/HUML.Huml-Lang.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<NotepadPlus>
+    <UserLang name="HUML" ext="huml" udlVersion="2.1">
+        <Settings>
+            <!--
+                caseIgnored="yes": HUML keyword matching is OrdinalIgnoreCase
+                (true / TRUE / True are all identical tokens).
+
+                No folding: HUML structure is indent-based; UDL has no
+                indent-aware fold markers.
+            -->
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <!--
+                Comments: HUML uses "# " (hash-space) as its line-comment prefix.
+                UDL cannot encode a trailing space in the delimiter (space is the
+                field separator), so we match on "#" alone. This means "#comment"
+                (without a space) is also highlighted — that is a parse error in
+                HUML but harmless here.
+                Slots: 00=line-open  01=line-continue  02=block-open  03=block-close
+            -->
+            <Keywords name="Comments">00# 01 02 03</Keywords>
+
+            <!--
+                Numbers: HUML supports decimal, hex (0x/0X), octal (0o/0O),
+                binary (0b/0B), floats with ".", scientific with "e"/"E", and
+                underscore digit separators (1_000_000).
+                Hex letters A-F are in extras so they colour inside hex literals.
+                "+" and "-" are in extras to cover exponent signs (e.g. 1.23e-4).
+            -->
+            <Keywords name="Numbers, prefix1">0x 0X</Keywords>
+            <Keywords name="Numbers, prefix2">0o 0O 0b 0B</Keywords>
+            <Keywords name="Numbers, extras1">_ . e E + - A B C D E F a b c d e f</Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+
+            <!--
+                Operators1: single-character structural tokens.
+                  ":"  scalar value indicator (key: value)
+                  ","  separator in inline collections
+                  "[" "]"  empty-list token []
+                  "{" "}"  empty-dict token {}
+                  "%"  version-directive prefix (%HUML)
+
+                Note: "::" (vector indicator) is two ":" characters; both
+                will be coloured as operators, which is visually correct.
+
+                "-" is in Operators2 (not Operators1). Operators2 only
+                colours a character when it is NOT flanked by word characters
+                on either side. This means:
+                  "min-revit-version" — "-" flanked by n/r, r/v (word chars)
+                    → not coloured ✓
+                  "  - ::" (list item) — "-" flanked by spaces
+                    → coloured ✓
+                  "-7" (negative number) — "-" flanked by space and digit
+                    → not coloured (the number gets number colour anyway) ✓
+            -->
+            <Keywords name="Operators1">: , [ ] { } %</Keywords>
+            <Keywords name="Operators2">-</Keywords>
+
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+
+            <!--
+                Keywords1: value-literal keywords (all case-insensitive per
+                Global caseIgnored="yes").
+                "+inf" and "-inf" are not listed — "+" and "-" are non-word
+                characters so UDL cannot match them as keyword prefixes. They
+                render as operator "+" or "-" followed by the keyword "inf".
+            -->
+            <Keywords name="Keywords1">true false null nan inf</Keywords>
+
+            <!--
+                Keywords2: the "HUML" word in the version directive.
+                Combined with "%" in Operators1 this gives the directive line
+                two distinct colours: % (operator) HUML (keyword2) v0.2 (default).
+            -->
+            <Keywords name="Keywords2">HUML</Keywords>
+
+            <Keywords name="Keywords3"></Keywords>
+            <Keywords name="Keywords4"></Keywords>
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+
+            <!--
+                Delimiters — 8 pairs, 3 slots each (open / escape / close),
+                slots 00–23.
+
+                Delimiter 1 (slots 00-02): triple-quoted multiline string.
+                  Open  """   no escape char   Close """
+                  Must be Delimiter 1 so it is tried BEFORE Delimiter 2;
+                  otherwise the lexer would match a bare " first.
+
+                Delimiter 2 (slots 03-05): double-quoted string.
+                  Open "   escape \   Close "
+                  Escape covers: \" \\ \/ \b \f \n \r \t \v
+
+                Delimiters 3–8 (slots 06-23): unused.
+
+                Known limitation: UDL has no single-line-only delimiter flag.
+                An unclosed "..." will colour the rest of the file as a string
+                (the standard "runaway string" UDL limitation).
+            -->
+            <Keywords name="Delimiters">00&quot;&quot;&quot; 01 02&quot;&quot;&quot; 03&quot; 04\ 05&quot; 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <!--
+                colorStyle controls which colours override the active theme:
+                  0 = fully inherit from theme (ignore both fgColor and bgColor)
+                  1 = use fgColor from UDL, bgColor from theme  ← used here
+                  2 = use bgColor from UDL, fgColor from theme
+                  3 = use both from UDL (hardcodes background — avoid this)
+
+                All active styles use colorStyle="1" so backgrounds are always
+                transparent (theme-driven). Unused style slots use colorStyle="0"
+                so they are completely invisible in any theme.
+
+                Palette targets the default Notepad++ white theme.
+                For dark themes install HUML.Huml-Lang_Dark.xml instead.
+            -->
+
+            <!-- Default text — bare keys, version string, etc. Fully inherited. -->
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+
+            <!-- Block comments — unused (HUML has no block comments). -->
+            <WordsStyle name="COMMENTS" fgColor="6A9955" bgColor="FFFFFF" colorStyle="1" fontStyle="2" nesting="0" />
+
+            <!-- Line comments: muted green, italic. -->
+            <WordsStyle name="LINE COMMENTS" fgColor="6A9955" bgColor="FFFFFF" colorStyle="1" fontStyle="2" nesting="0" />
+
+            <!-- Number literals: dark teal-green. -->
+            <WordsStyle name="NUMBERS" fgColor="09885A" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Keywords1 (true/false/null/nan/inf): bold blue. -->
+            <WordsStyle name="KEYWORDS1" fgColor="0000FF" bgColor="FFFFFF" colorStyle="1" fontStyle="1" nesting="0" />
+
+            <!-- Keywords2 (HUML directive word): muted violet. -->
+            <WordsStyle name="KEYWORDS2" fgColor="800080" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Keywords3–8: unused. -->
+            <WordsStyle name="KEYWORDS3" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+
+            <!-- Operators (: :: , - [ ] { } %): bright purple. -->
+            <WordsStyle name="OPERATORS" fgColor="AF00DB" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Folding styles — unused (no fold markers in HUML). -->
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+
+            <!-- Delimiter 1: triple-quoted multiline string — dark red. -->
+            <WordsStyle name="DELIMITERS1" fgColor="A31515" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Delimiter 2: double-quoted string — same dark red family. -->
+            <WordsStyle name="DELIMITERS2" fgColor="A31515" bgColor="FFFFFF" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Delimiters 3–8: unused. -->
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" colorStyle="0" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/UDLs/HUML.Huml-Lang_Dark.xml
+++ b/UDLs/HUML.Huml-Lang_Dark.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<NotepadPlus>
+    <UserLang name="HUML Dark Mode" ext="huml" udlVersion="2.1">
+        <Settings>
+            <!--
+                caseIgnored="yes": HUML keyword matching is OrdinalIgnoreCase
+                (true / TRUE / True are all identical tokens).
+
+                No folding: HUML structure is indent-based; UDL has no
+                indent-aware fold markers.
+            -->
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <!--
+                Comments: HUML uses "# " (hash-space) as its line-comment prefix.
+                UDL cannot encode a trailing space in the delimiter (space is the
+                field separator), so we match on "#" alone. This means "#comment"
+                (without a space) is also highlighted — that is a parse error in
+                HUML but harmless here.
+                Slots: 00=line-open  01=line-continue  02=block-open  03=block-close
+            -->
+            <Keywords name="Comments">00# 01 02 03</Keywords>
+
+            <!--
+                Numbers: HUML supports decimal, hex (0x/0X), octal (0o/0O),
+                binary (0b/0B), floats with ".", scientific with "e"/"E", and
+                underscore digit separators (1_000_000).
+                Hex letters A-F are in extras so they colour inside hex literals.
+                "+" and "-" are in extras to cover exponent signs (e.g. 1.23e-4).
+            -->
+            <Keywords name="Numbers, prefix1">0x 0X</Keywords>
+            <Keywords name="Numbers, prefix2">0o 0O 0b 0B</Keywords>
+            <Keywords name="Numbers, extras1">_ . e E + - A B C D E F a b c d e f</Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+
+            <!--
+                Operators1: single-character structural tokens.
+                  ":"  scalar value indicator (key: value)
+                  ","  separator in inline collections
+                  "[" "]"  empty-list token []
+                  "{" "}"  empty-dict token {}
+                  "%"  version-directive prefix (%HUML)
+
+                Note: "::" (vector indicator) is two ":" characters; both
+                will be coloured as operators, which is visually correct.
+
+                "-" is in Operators2 (not Operators1). Operators2 only
+                colours a character when it is NOT flanked by word characters
+                on either side. This means:
+                  "min-revit-version" — "-" flanked by n/r, r/v (word chars)
+                    → not coloured ✓
+                  "  - ::" (list item) — "-" flanked by spaces
+                    → coloured ✓
+                  "-7" (negative number) — "-" flanked by space and digit
+                    → not coloured (the number gets number colour anyway) ✓
+            -->
+            <Keywords name="Operators1">: , [ ] { } %</Keywords>
+            <Keywords name="Operators2">-</Keywords>
+
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+
+            <!--
+                Keywords1: value-literal keywords (all case-insensitive per
+                Global caseIgnored="yes").
+                "+inf" and "-inf" are not listed — "+" and "-" are non-word
+                characters so UDL cannot match them as keyword prefixes. They
+                render as operator "+" or "-" followed by the keyword "inf".
+            -->
+            <Keywords name="Keywords1">true false null nan inf</Keywords>
+
+            <!--
+                Keywords2: the "HUML" word in the version directive.
+                Combined with "%" in Operators1 this gives the directive line
+                two distinct colours: % (operator) HUML (keyword2) v0.2 (default).
+            -->
+            <Keywords name="Keywords2">HUML</Keywords>
+
+            <Keywords name="Keywords3"></Keywords>
+            <Keywords name="Keywords4"></Keywords>
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+
+            <!--
+                Delimiters — 8 pairs, 3 slots each (open / escape / close),
+                slots 00–23.
+
+                Delimiter 1 (slots 00-02): triple-quoted multiline string.
+                  Open  """   no escape char   Close """
+                  Must be Delimiter 1 so it is tried BEFORE Delimiter 2;
+                  otherwise the lexer would match a bare " first.
+
+                Delimiter 2 (slots 03-05): double-quoted string.
+                  Open "   escape \   Close "
+                  Escape covers: \" \\ \/ \b \f \n \r \t \v
+
+                Delimiters 3–8 (slots 06-23): unused.
+            -->
+            <Keywords name="Delimiters">00&quot;&quot;&quot; 01 02&quot;&quot;&quot; 03&quot; 04\ 05&quot; 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <!--
+                colorStyle controls which colours override the active theme:
+                  0 = fully inherit from theme (ignore both fgColor and bgColor)
+                  1 = use fgColor from UDL, bgColor from theme  ← used here
+                  2 = use bgColor from UDL, fgColor from theme
+                  3 = use both from UDL (hardcodes background — avoid this)
+
+                All active styles use colorStyle="1" so backgrounds are always
+                transparent (theme-driven). Unused style slots use colorStyle="0".
+
+                Palette inspired by VS Code Dark+ — calibrated for dark backgrounds
+                (Notepad++ dark mode, Dracula, Monokai, etc.).
+                For light themes install HUML.Huml-Lang.xml instead.
+            -->
+
+            <!-- Default text — bare keys, version string, etc. Fully inherited. -->
+            <WordsStyle name="DEFAULT" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+
+            <!-- Block comments — unused (HUML has no block comments). -->
+            <WordsStyle name="COMMENTS" fgColor="6A9955" bgColor="1E1E1E" colorStyle="1" fontStyle="2" nesting="0" />
+
+            <!-- Line comments: muted green, italic (VS Code Dark+ #6A9955). -->
+            <WordsStyle name="LINE COMMENTS" fgColor="6A9955" bgColor="1E1E1E" colorStyle="1" fontStyle="2" nesting="0" />
+
+            <!-- Number literals: soft sage green (VS Code Dark+ #B5CEA8). -->
+            <WordsStyle name="NUMBERS" fgColor="B5CEA8" bgColor="1E1E1E" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Keywords1 (true/false/null/nan/inf): bold cornflower blue (VS Code Dark+ #569CD6). -->
+            <WordsStyle name="KEYWORDS1" fgColor="569CD6" bgColor="1E1E1E" colorStyle="1" fontStyle="1" nesting="0" />
+
+            <!-- Keywords2 (HUML directive word): warm yellow (VS Code Dark+ function colour #DCDCAA). -->
+            <WordsStyle name="KEYWORDS2" fgColor="DCDCAA" bgColor="1E1E1E" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Keywords3–8: unused. -->
+            <WordsStyle name="KEYWORDS3" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+
+            <!-- Operators (: :: , - [ ] { } %): light violet (VS Code Dark+ #C586C0). -->
+            <WordsStyle name="OPERATORS" fgColor="C586C0" bgColor="1E1E1E" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Folding styles — unused (no fold markers in HUML). -->
+            <WordsStyle name="FOLDER IN CODE1" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+
+            <!-- Delimiter 1: triple-quoted multiline string — warm orange-red (VS Code Dark+ #CE9178). -->
+            <WordsStyle name="DELIMITERS1" fgColor="CE9178" bgColor="1E1E1E" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Delimiter 2: double-quoted string — same warm orange-red family. -->
+            <WordsStyle name="DELIMITERS2" fgColor="CE9178" bgColor="1E1E1E" colorStyle="1" fontStyle="0" nesting="0" />
+
+            <!-- Delimiters 3–8: unused. -->
+            <WordsStyle name="DELIMITERS3" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="D4D4D4" bgColor="1E1E1E" colorStyle="0" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -1604,6 +1604,24 @@
       "autoCompletionAuthor": "generate_ac.py"
     },
     {
+      "id-name": "HUML.Huml-Lang",
+      "display-name": "HUML",
+      "author": "Shade666",
+      "version": "0.2",
+      "repository": "",
+      "description": "HUML (Human-oriented Markup Language) — config format with YAML-like blocks and JSON-like inline collections. Light theme. Targets HUML spec v0.2.",
+      "sample": "HUML.Huml-Lang.huml"
+    },
+    {
+      "id-name": "HUML.Huml-Lang_Dark",
+      "display-name": "HUML Dark Mode",
+      "author": "Shade666",
+      "version": "0.2",
+      "repository": "",
+      "description": "HUML (Human-oriented Markup Language) — dark theme variant, VS Code Dark+ inspired palette. Targets HUML spec v0.2.",
+      "sample": "HUML.Huml-Lang.huml"
+    },
+    {
       "id-name": "iCalendar_by-jfreundo",
       "display-name": "iCalendar",
       "version": "Tue, 19 Jan 2010 22:37:41 GMT",


### PR DESCRIPTION
Adds a User Defined Language for **HUML** (Human-oriented Markup Language) — a YAML-like
configuration format with JSON-style inline collections. Targets HUML spec v0.2.

- **Spec**: <https://github.com/huml-lang/huml>
- **Reference .NET implementation**: <https://github.com/Shade666/huml-dotnet>
- **File extension**: `.huml`

Two variants are submitted in one PR (related theme pair):

| File | Theme target | `display-name` |
| --- | --- | --- |
| `UDLs/HUML.Huml-Lang.xml` | Light (default Notepad++ theme) | `HUML` |
| `UDLs/HUML.Huml-Lang_Dark.xml` | Dark (VS Code Dark+ inspired) | `HUML Dark Mode` |

Both variants use `colorStyle="1"` on every active style — only foreground colours are set;
backgrounds are always inherited from the user's active theme.

Sample file `UDL-samples/HUML.Huml-Lang.huml` exercises every UDL category: version
directive, all number formats (decimal, hex `0x`, octal `0o`, binary `0b`, scientific,
underscore-separated), both string forms (double-quoted and triple-quoted multiline), empty
collections `[]`/`{}`, inline and block lists, inline and block dicts, and deep nesting.

### Known limitations (intrinsic to UDL — not bugs)

- Bare keys vs quoted-string values are not distinguished — UDL has no positional awareness.
- HUML's strict whitespace rules (`#` must be followed by a space; no double-space after `:`;
  no tab indentation) are not enforced by the highlighter.
- No code folding — HUML structure is indent-based; UDL folding needs explicit markers.
