### PR TITLE
Add SysML v2 User Defined Language for Notepad++

### DIFF
--- a/UDLs/sysmlv2_omg_byaklira.xml
+++ b/UDLs/sysmlv2_omg_byaklira.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NotepadPlus>
+    <!--
+      Notepad++ UDL for OMG SysML v2 textual notation.
+      Based on:
+        - OMG SysML v2.0, Part 1: Language Specification, formal/2026-03-02
+          Section 8.2.2.1.2 (Lexical Structure)
+        - OMG KerML v1.0, formal/2026-03-01
+          Section 8.2.2 (Lexical Structure), inherited by SysML v2
+
+      Note: "new" is highlighted for practical compatibility because the
+      inherited KerML constructor-expression grammar uses the terminal 'new',
+      and SysML v2 examples use it, although it is not present in the SysML v2
+      reserved-keyword table.
+    -->
+    <UserLang name="SysML v2" ext="sysml" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="yes" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="yes" Keywords8="yes" />
+        </Settings>
+        <KeywordLists>
+            <!-- KerML/SysML notes and regular comments: //..., //*...*/, /*...*/ -->
+            <Keywords name="Comments">00// 01 02 03/* 04*/</Keywords>
+
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range">..</Keywords>
+
+            <!-- KerML symbol tokens inherited by SysML. # and @ are styled separately below. -->
+            <Keywords name="Operators1">( ) { } [ ] ; , ~ % &amp; ^ | * ** + - / -&gt; $ . .. : :: :&gt; :&gt;&gt; ::&gt; =&gt; &lt; &lt;= = := == === != !== &gt; &gt;= ? ?? .?</Keywords>
+            <Keywords name="Operators2"></Keywords>
+
+            <!-- Folding follows SysML bodies enclosed in braces. -->
+            <Keywords name="Folders in code1, open">{</Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close">}</Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open">/*</Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close">*/</Keywords>
+
+            <!-- 1: definitions/usages and major modeling constructs -->
+            <Keywords name="Keywords1">action actor allocation analysis attribute calc case concern connection constraint def dependency enum flow interface item message metadata objective occurrence package part port rendering requirement state succession transition use verification view viewpoint</Keywords>
+
+            <!-- 2: relationships, typing, allocation, satisfaction and verification -->
+            <Keywords name="Keywords2">allocate bind binding connect crosses defined exhibit expose hastype include istype redefines references render require satisfy specializes subsets verify</Keywords>
+
+            <!-- 3: behavior/control-flow keywords (+ new from inherited KerML constructor grammar) -->
+            <Keywords name="Keywords3">accept after assert assign assume decide do else entry event exit first for fork if join loop merge new parallel perform return send terminate then until via when while</Keywords>
+
+            <!-- 4: modifiers, direction, visibility, context and variability -->
+            <Keywords name="Keywords4">abstract all as at by constant default derived end frame from in individual inout nonunique of ordered out private protected public ref snapshot stakeholder standard subject timeslice to variant variation</Keywords>
+
+            <!-- 5: logical operators and literals -->
+            <Keywords name="Keywords5">and false implies not null or true xor</Keywords>
+
+            <!-- 6: namespace, annotation and documentation-related keywords -->
+            <Keywords name="Keywords6">about alias comment doc filter import language library locale meta rep</Keywords>
+
+            <!-- 7: SysML user-defined keywords, e.g. #situation or #SecurityRelated -->
+            <Keywords name="Keywords7">#</Keywords>
+
+            <!-- 8: metadata annotations, e.g. @CommandMetadata -->
+            <Keywords name="Keywords8">@</Keywords>
+
+            <!-- Delimiter 1: STRING_VALUE "...". Delimiter 2: unrestricted NAME '...'. -->
+            <Keywords name="Delimiters">00&quot; 01\ 02&quot; 03&apos; 04\ 05&apos; 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+
+        <Styles>
+            <!-- colorStyle=0 makes DEFAULT inherit the active Notepad++ theme. -->
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+
+            <!-- Styles inherit the active theme background (colorStyle=1). -->
+            <WordsStyle name="COMMENTS" fgColor="608B4E" bgColor="FFFFFF" fontName="" fontStyle="2" nesting="0" colorStyle="1" />
+            <WordsStyle name="LINE COMMENTS" fgColor="608B4E" bgColor="FFFFFF" fontName="" fontStyle="2" nesting="0" colorStyle="1" />
+            <WordsStyle name="NUMBERS" fgColor="B05A00" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+
+            <WordsStyle name="KEYWORDS1" fgColor="005CC5" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS2" fgColor="6F42C1" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS3" fgColor="D73A49" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS4" fgColor="795548" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS5" fgColor="B31D28" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS6" fgColor="007A6E" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS7" fgColor="C2185B" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+            <WordsStyle name="KEYWORDS8" fgColor="8E44AD" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+
+            <WordsStyle name="OPERATORS" fgColor="666666" bgColor="FFFFFF" fontName="" fontStyle="1" nesting="0" colorStyle="1" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="666666" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="666666" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="608B4E" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+
+            <WordsStyle name="DELIMITERS1" fgColor="A31515" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+            <WordsStyle name="DELIMITERS2" fgColor="986801" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="1" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" colorStyle="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/udl-list.json
+++ b/udl-list.json
@@ -3488,6 +3488,14 @@
       "autoCompletionAuthor": "generate_ac.py"
     },
     {
+      "id-name": "sysmlv2_omg_byaklira",
+      "display-name": "SysML v2",
+      "version": "Fri, 04 Sep 2026 08:26:00 GMT",
+      "repository": "",
+      "description": "OMG SysML v2",
+      "author": "aklira"
+    },
+    {
       "id-name": "SystemRDL2_byKeithBrady",
       "display-name": "SystemRDL 2.0",
       "version": "Sat, 27 Jun 2019 09:22:00 GMT",


### PR DESCRIPTION
## Add User Defined Language support for SysML v2

This pull request adds a Notepad++ User Defined Language (UDL) definition for **SysML v2**.

The UDL is based on the OMG SysML v2 and KerML language specifications and provides syntax highlighting for the main lexical elements of the textual SysML v2 notation.

### Supported syntax

* SysML v2 reserved keywords
* Common modeling constructs such as `part`, `port`, `item`, `attribute`, `action`, `state`, `requirement`, `verification`, `view`, `viewpoint`, `connection`, and `interface`
* Relationship keywords and operators such as `specializes`, `subsets`, `redefines`, `:>`, `::>`, and `:>>`
* Line and block comments
* String literals
* Quoted identifiers
* Numeric literals
* SysML/KerML operators
* Metadata annotations
* User-defined keywords prefixed with `#`
* Code folding based on `{ ... }` blocks

The `.sysml` file extension is automatically associated with the language.

### References

The definition was created based on the official OMG specifications:

* SysML v2 Language Specification
* KerML Specification

The goal is to provide lightweight and convenient syntax highlighting for users editing textual SysML v2 models in Notepad++.

As this is implemented as a Notepad++ UDL, it provides lexical highlighting only and does not attempt semantic or context-sensitive parsing of SysML v2 models.
